### PR TITLE
feat: async migration for OpenWebUI v0.9.0 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.14']
 
     steps:
     - uses: actions/checkout@v4
@@ -39,4 +39,4 @@ jobs:
         pip install -e .
 
     - name: Test with pytest
-      run: pytest -v
+      run: pytest

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "owuinc"
 copyright = "2026, soakedcardinal"
 author = "soakedcardinal"
-release = "2.3.0"
+release = "2.4.0"
 extensions = ["sphinx.ext.autodoc"]
 exclude_patterns: list[str] = []
 html_theme = "sphinx_rtd_theme"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "owuinc"
 copyright = "2026, soakedcardinal"
 author = "soakedcardinal"
-release = "2.4.0"
+release = "3.0.0"
 extensions = ["sphinx.ext.autodoc"]
 exclude_patterns: list[str] = []
 html_theme = "sphinx_rtd_theme"

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -4,7 +4,7 @@ author: soakedcardinal
 git_url: https://github.com/soakedcardinal/owuinc
 description: Manage files, tasks, and calendars via WebDAV and CalDAV.
 requirements: caldav>=3.0.0,icalendar,aiowebdav2
-version: 2.4.0
+version: 3.0.0
 license: MIT
 """
 

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -367,32 +367,38 @@ class Tools:
     async def get_calendars(self) -> list[str]:
         """Retrieve available calendars"""
         client = await self.caldav_client
-        principal = await client.principal()
-        calendars = await principal.get_calendars()
-        available = [await c.get_display_name() for c in calendars]
-        log(f"found {len(available)} calendars: {available!r}")
+        try:
+            principal = await client.principal()
+            calendars = await principal.get_calendars()
+            available = [await c.get_display_name() for c in calendars]
+            log(f"found {len(available)} calendars: {available!r}")
 
-        return [
-            cal_name
-            for cal_name in available
-            if is_whitelisted(self.valves.CALENDAR_WHITELIST, cal_name)
-        ]
+            return [
+                cal_name
+                for cal_name in available
+                if is_whitelisted(self.valves.CALENDAR_WHITELIST, cal_name)
+            ]
+        finally:
+            await client.close()
 
     @tool_logger
     @caldav_safe
     async def get_task_lists(self) -> list[str]:
         """Retrieve available task lists"""
         client = await self.caldav_client
-        principal = await client.principal()
-        calendars = await principal.get_calendars()
-        available = [await c.get_display_name() for c in calendars]
-        log(f"found {len(available)} task lists: {available!r}")
+        try:
+            principal = await client.principal()
+            calendars = await principal.get_calendars()
+            available = [await c.get_display_name() for c in calendars]
+            log(f"found {len(available)} task lists: {available!r}")
 
-        return [
-            tl
-            for tl in available
-            if is_whitelisted(self.valves.TASK_LIST_WHITELIST, tl)
-        ]
+            return [
+                tl
+                for tl in available
+                if is_whitelisted(self.valves.TASK_LIST_WHITELIST, tl)
+            ]
+        finally:
+            await client.close()
 
     @tool_logger
     @webdav_safe
@@ -828,50 +834,53 @@ class Tools:
             raise Exception(f"{list_name!r} not whitelisted")
 
         client = await self.caldav_client
-        principal = await client.principal()
-        cal = await self._get_calendar(principal, list_name)
-        todos = await cal.todos()
+        try:
+            principal = await client.principal()
+            cal = await self._get_calendar(principal, list_name)
+            todos = await cal.todos()
 
-        task_map: dict[str, dict] = {}
-        for todo in todos:
-            task_map[todo.component["uid"]] = {
-                key: todo.component.get(key)
-                for key in [
-                    "uid",
-                    "summary",
-                    "description",
-                    "location",
-                    "url",
-                    "priority",
-                    "related-to",
-                ]
-                if todo.component.get(key) is not None
-            }
-        subtasks_map: dict[str, list[str]] = {}
-        for uid, task_data in task_map.items():
-            parent_id = task_data.get("related-to")
-            if parent_id and parent_id in task_map:
-                if parent_id not in subtasks_map:
-                    subtasks_map[parent_id] = []
-                subtasks_map[parent_id].append(uid)
+            task_map: dict[str, dict] = {}
+            for todo in todos:
+                task_map[todo.component["uid"]] = {
+                    key: todo.component.get(key)
+                    for key in [
+                        "uid",
+                        "summary",
+                        "description",
+                        "location",
+                        "url",
+                        "priority",
+                        "related-to",
+                    ]
+                    if todo.component.get(key) is not None
+                }
+            subtasks_map: dict[str, list[str]] = {}
+            for uid, task_data in task_map.items():
+                parent_id = task_data.get("related-to")
+                if parent_id and parent_id in task_map:
+                    if parent_id not in subtasks_map:
+                        subtasks_map[parent_id] = []
+                    subtasks_map[parent_id].append(uid)
 
-        def build_subtree(task_id):
-            task_data = task_map.get(task_id)
-            if not task_data:
-                return []
-            node = {k: v for k, v in task_data.items() if k != "related-to"}
-            if task_id in subtasks_map:
-                node["subtasks"] = [
-                    build_subtree(child_id) for child_id in subtasks_map[task_id]
-                ]
-            return node
+            def build_subtree(task_id):
+                task_data = task_map.get(task_id)
+                if not task_data:
+                    return []
+                node = {k: v for k, v in task_data.items() if k != "related-to"}
+                if task_id in subtasks_map:
+                    node["subtasks"] = [
+                        build_subtree(child_id) for child_id in subtasks_map[task_id]
+                    ]
+                return node
 
-        tree = []
-        for task_id, task_data in task_map.items():
-            parent_id = task_data.get("related-to")
-            if not parent_id or parent_id not in task_map:
-                tree.append(build_subtree(task_id))
-        return tree
+            tree = []
+            for task_id, task_data in task_map.items():
+                parent_id = task_data.get("related-to")
+                if not parent_id or parent_id not in task_map:
+                    tree.append(build_subtree(task_id))
+            return tree
+        finally:
+            await client.close()
 
     @tool_logger
     @caldav_safe
@@ -896,38 +905,41 @@ class Tools:
         if not (summary or uid):
             raise Exception("must specify summary or uid of task to edit")
         client = await self.caldav_client
-        principal = await client.principal()
-        cal = await self._get_calendar(principal, list_name)
-        todo = None
-        if uid:
-            todo = await cal.todo_by_uid(uid)
-        elif summary is not None:
-            matches = []
-            todos = await cal.todos()
-            for todo in todos:
-                if summary.strip() in todo.component["summary"]:
-                    matches.append(todo.component["uid"])
-            if len(matches) > 1:
-                raise Exception(f"Multiple matches for {summary!r}: {matches}")
-            elif len(matches) == 1:
-                todo = await cal.todo_by_uid(matches[0])
-        if not todo:
-            raise Exception("task not found")
-        if new_summary:
-            todo.component["summary"] = new_summary.strip()
-        if new_location:
-            todo.component["location"] = new_location
-        if new_description:
-            todo.component["description"] = new_description
-        if new_categories:
-            todo.component["categories"] = new_categories
-        if new_priority:
-            todo.component["priority"] = max(0, min(9, new_priority))
-        if new_url:
-            todo.component["url"] = new_url
-        if new_related_to:
-            todo.component["related-to"] = new_related_to
-        await todo.save()
+        try:
+            principal = await client.principal()
+            cal = await self._get_calendar(principal, list_name)
+            todo = None
+            if uid:
+                todo = await cal.todo_by_uid(uid)
+            elif summary is not None:
+                matches = []
+                todos = await cal.todos()
+                for todo in todos:
+                    if summary.strip() in todo.component["summary"]:
+                        matches.append(todo.component["uid"])
+                if len(matches) > 1:
+                    raise Exception(f"Multiple matches for {summary!r}: {matches}")
+                elif len(matches) == 1:
+                    todo = await cal.todo_by_uid(matches[0])
+            if not todo:
+                raise Exception("task not found")
+            if new_summary:
+                todo.component["summary"] = new_summary.strip()
+            if new_location:
+                todo.component["location"] = new_location
+            if new_description:
+                todo.component["description"] = new_description
+            if new_categories:
+                todo.component["categories"] = new_categories
+            if new_priority:
+                todo.component["priority"] = max(0, min(9, new_priority))
+            if new_url:
+                todo.component["url"] = new_url
+            if new_related_to:
+                todo.component["related-to"] = new_related_to
+            await todo.save()
+        finally:
+            await client.close()
 
     @tool_logger
     @caldav_safe
@@ -945,24 +957,29 @@ class Tools:
         if not (summary or uid):
             raise Exception("must specify summary or uid of task to edit")
         client = await self.caldav_client
-        principal = await client.principal()
-        cal = await self._get_calendar(principal, list_name)
-        todo = None
-        if uid:
-            todo = await cal.todo_by_uid(uid)
-        elif summary is not None:
-            matches = []
-            todos = await cal.todos()
-            for todo in todos:
-                if summary.strip() in todo.component["summary"]:
-                    matches.append(todo.component["uid"])
-            if len(matches) > 1:
-                raise Exception(f"Error: Multiple matches for {summary!r}: {matches}")
-            elif len(matches) == 1:
-                todo = await cal.todo_by_uid(matches[0])
-        if not todo:
-            raise Exception("Error: task not found")
-        await todo.delete()
+        try:
+            principal = await client.principal()
+            cal = await self._get_calendar(principal, list_name)
+            todo = None
+            if uid:
+                todo = await cal.todo_by_uid(uid)
+            elif summary is not None:
+                matches = []
+                todos = await cal.todos()
+                for todo in todos:
+                    if summary.strip() in todo.component["summary"]:
+                        matches.append(todo.component["uid"])
+                if len(matches) > 1:
+                    raise Exception(
+                        f"Error: Multiple matches for {summary!r}: {matches}"
+                    )
+                elif len(matches) == 1:
+                    todo = await cal.todo_by_uid(matches[0])
+            if not todo:
+                raise Exception("Error: task not found")
+            await todo.delete()
+        finally:
+            await client.close()
 
     @tool_logger
     @caldav_safe
@@ -986,48 +1003,51 @@ class Tools:
         zi = ZoneInfo(__user__["timezone"])
         now = datetime.now(zi).replace(second=0, microsecond=0)
         client = await self.caldav_client
-        principal = await client.principal()
-        cal = await self._get_calendar(principal, calendar_name)
+        try:
+            principal = await client.principal()
+            cal = await self._get_calendar(principal, calendar_name)
 
-        uid = str(uuid.uuid4())
-        e = Event()
-        e.add("uid", uid)
-        e.add("summary", summary)
-        e.add("dtstamp", now)
-        e.add("created", now)
-        e.add("last-modified", now)
+            uid = str(uuid.uuid4())
+            e = Event()
+            e.add("uid", uid)
+            e.add("summary", summary)
+            e.add("dtstamp", now)
+            e.add("created", now)
+            e.add("last-modified", now)
 
-        if start:
-            dtstart = datetime.fromisoformat(start)
-            if dtstart.tzinfo is None:
-                dtstart = dtstart.replace(tzinfo=zi)
-        else:
-            dtstart = now
-        if end:
-            dtend = datetime.fromisoformat(end)
-            if dtend.tzinfo is None:
-                dtend = dtend.replace(tzinfo=zi)
-        else:
-            dtend = dtstart + timedelta(hours=1.0)
-        e.add("dtstart", dtstart)
-        e.add("dtend", dtend)
+            if start:
+                dtstart = datetime.fromisoformat(start)
+                if dtstart.tzinfo is None:
+                    dtstart = dtstart.replace(tzinfo=zi)
+            else:
+                dtstart = now
+            if end:
+                dtend = datetime.fromisoformat(end)
+                if dtend.tzinfo is None:
+                    dtend = dtend.replace(tzinfo=zi)
+            else:
+                dtend = dtstart + timedelta(hours=1.0)
+            e.add("dtstart", dtstart)
+            e.add("dtend", dtend)
 
-        if description:
-            e.add("description", description)
-        if location:
-            e.add("location", location)
-        if rrule:
-            e.add("rrule", rrule)
+            if description:
+                e.add("description", description)
+            if location:
+                e.add("location", location)
+            if rrule:
+                e.add("rrule", rrule)
 
-        if alarms:
-            for r in parse_reminders(alarms):
-                a = Alarm()
-                a.add("action", "DISPLAY")
-                a.add("trigger", timedelta(minutes=-r.get("minutes")))
-                a.add("description", summary)
-                e.add_component(a)
-        await cal.save_event(ical=e)
-        return uid
+            if alarms:
+                for r in parse_reminders(alarms):
+                    a = Alarm()
+                    a.add("action", "DISPLAY")
+                    a.add("trigger", timedelta(minutes=-r.get("minutes")))
+                    a.add("description", summary)
+                    e.add_component(a)
+            await cal.save_event(ical=e)
+            return uid
+        finally:
+            await client.close()
 
     @tool_logger
     @caldav_safe
@@ -1048,23 +1068,26 @@ class Tools:
 
         uid = str(uuid.uuid4())
         client = await self.caldav_client
-        principal = await client.principal()
-        calendars = await principal.get_calendars()
-        available_lists = [await c.get_display_name() for c in calendars]
-        if list_name not in available_lists:
-            log_err("invalid task list")
-            raise Exception("invalid task list")
-        cal = await self._get_calendar(principal, list_name)
-        await cal.save_todo(
-            uid=uid,
-            summary=summary,
-            priority=priority,
-            description=description,
-            categories=categories,
-            url=url,
-            location=location,
-        )
-        return uid
+        try:
+            principal = await client.principal()
+            calendars = await principal.get_calendars()
+            available_lists = [await c.get_display_name() for c in calendars]
+            if list_name not in available_lists:
+                log_err("invalid task list")
+                raise Exception("invalid task list")
+            cal = await self._get_calendar(principal, list_name)
+            await cal.save_todo(
+                uid=uid,
+                summary=summary,
+                priority=priority,
+                description=description,
+                categories=categories,
+                url=url,
+                location=location,
+            )
+            return uid
+        finally:
+            await client.close()
 
     # TODO this duplicates edit task should be a wrapper
     @tool_logger
@@ -1081,25 +1104,28 @@ class Tools:
             raise Exception(f"{list_name!r} not whitelisted")
 
         client = await self.caldav_client
-        principal = await client.principal()
-        cal = await self._get_calendar(principal, list_name)
-        if uid:
-            todo = await cal.todo_by_uid(uid)
-        elif summary is not None:
-            matches = []
-            todos = await cal.todos()
-            for t in todos:
-                if summary.strip() in t.component["summary"]:
-                    matches.append(t)
-            if len(matches) > 1:
-                raise Exception(f"multiple matches found for {summary!r}")
-            if len(matches) == 0:
-                raise Exception(
-                    f"Task with summary {summary!r} not found in list {list_name!r}"
-                )
-            todo = matches[0]
-        todo.component["status"] = "COMPLETED"
-        await todo.save()
+        try:
+            principal = await client.principal()
+            cal = await self._get_calendar(principal, list_name)
+            if uid:
+                todo = await cal.todo_by_uid(uid)
+            elif summary is not None:
+                matches = []
+                todos = await cal.todos()
+                for t in todos:
+                    if summary.strip() in t.component["summary"]:
+                        matches.append(t)
+                if len(matches) > 1:
+                    raise Exception(f"multiple matches found for {summary!r}")
+                if len(matches) == 0:
+                    raise Exception(
+                        f"Task with summary {summary!r} not found in list {list_name!r}"
+                    )
+                todo = matches[0]
+            todo.component["status"] = "COMPLETED"
+            await todo.save()
+        finally:
+            await client.close()
 
     @tool_logger
     @caldav_safe
@@ -1128,56 +1154,59 @@ class Tools:
         tz = __user__["timezone"]
         zi = ZoneInfo(tz)
         client = await self.caldav_client
-        principal = await client.principal()
-        cal = await self._get_calendar(principal, calendar_name)
+        try:
+            principal = await client.principal()
+            cal = await self._get_calendar(principal, calendar_name)
 
-        e = None
-        if uid:
-            e = await cal.event_by_uid(uid)
-        elif summary is not None:
-            matches = []
-            events = await cal.events()
-            for e in events:
-                if summary.strip() in e.component["summary"]:
-                    matches.append(e.component["uid"])
-            if len(matches) > 1:
-                raise Exception("Error: multiple matches")
-            elif len(matches) == 1:
-                e = await cal.event_by_uid(matches[0])
-        if not e:
-            raise Exception("Error: event not found")
+            e = None
+            if uid:
+                e = await cal.event_by_uid(uid)
+            elif summary is not None:
+                matches = []
+                events = await cal.events()
+                for e in events:
+                    if summary.strip() in e.component["summary"]:
+                        matches.append(e.component["uid"])
+                if len(matches) > 1:
+                    raise Exception("Error: multiple matches")
+                elif len(matches) == 1:
+                    e = await cal.event_by_uid(matches[0])
+            if not e:
+                raise Exception("Error: event not found")
 
-        if new_start:
-            dtstart = datetime.fromisoformat(new_start)
-            if dtstart.tzinfo is None:
-                dtstart = dtstart.replace(tzinfo=zi)
-            e.component["dtstart"].dt = dtstart
-        if new_end:
-            dtend = datetime.fromisoformat(new_end)
-            if dtend.tzinfo is None:
-                dtend = dtend.replace(tzinfo=zi)
-            e.component["dtend"].dt = dtend
-        if new_summary:
-            e.component["summary"] = new_summary.strip()
-        if new_location:
-            e.component["location"] = new_location
-        if new_description:
-            e.component["description"] = new_description
-        if new_rrule:
-            e.component["rrule"] = new_rrule
-        if new_alarms:
-            valarm_subs = [
-                sub for sub in e.component.subcomponents if sub.name == "VALARM"
-            ]
-            for sub in valarm_subs[:]:
-                e.component.subcomponents.remove(sub)
-            for reminder in parse_reminders(new_alarms):
-                a = Alarm()
-                a.add("action", "DISPLAY")
-                a.add("trigger", timedelta(minutes=-reminder.get("minutes")))
-                a.add("description", e.component["summary"])
-                e.component.add_component(a)
-        await e.save()
+            if new_start:
+                dtstart = datetime.fromisoformat(new_start)
+                if dtstart.tzinfo is None:
+                    dtstart = dtstart.replace(tzinfo=zi)
+                e.component["dtstart"].dt = dtstart
+            if new_end:
+                dtend = datetime.fromisoformat(new_end)
+                if dtend.tzinfo is None:
+                    dtend = dtend.replace(tzinfo=zi)
+                e.component["dtend"].dt = dtend
+            if new_summary:
+                e.component["summary"] = new_summary.strip()
+            if new_location:
+                e.component["location"] = new_location
+            if new_description:
+                e.component["description"] = new_description
+            if new_rrule:
+                e.component["rrule"] = new_rrule
+            if new_alarms:
+                valarm_subs = [
+                    sub for sub in e.component.subcomponents if sub.name == "VALARM"
+                ]
+                for sub in valarm_subs[:]:
+                    e.component.subcomponents.remove(sub)
+                for reminder in parse_reminders(new_alarms):
+                    a = Alarm()
+                    a.add("action", "DISPLAY")
+                    a.add("trigger", timedelta(minutes=-reminder.get("minutes")))
+                    a.add("description", e.component["summary"])
+                    e.component.add_component(a)
+            await e.save()
+        finally:
+            await client.close()
 
     @tool_logger
     @caldav_safe
@@ -1193,97 +1222,103 @@ class Tools:
 
         event_data = []
         client = await self.caldav_client
-        principal = await client.principal()
-        cal = await self._get_calendar(principal, calendar_name)
-        events = await cal.search(
-            start=datetime.now(ZoneInfo(__user__["timezone"])),
-            expand=False,
-            event=True,
-        )
+        try:
+            principal = await client.principal()
+            cal = await self._get_calendar(principal, calendar_name)
+            events = await cal.search(
+                start=datetime.now(ZoneInfo(__user__["timezone"])),
+                expand=False,
+                event=True,
+            )
 
-        for e in events:
-            event_dict = {}
+            for e in events:
+                event_dict = {}
 
-            for field in [
-                "uid",
-                "summary",
-                "description",
-                "location",
-                "categories",
-                "organizer",
-                "url",
-            ]:
-                if val := e.component.get(field):
-                    event_dict[field] = val
+                for field in [
+                    "uid",
+                    "summary",
+                    "description",
+                    "location",
+                    "categories",
+                    "organizer",
+                    "url",
+                ]:
+                    if val := e.component.get(field):
+                        event_dict[field] = val
 
-            dtstart_val = e.component.get("dtstart")
-            dtend_val = e.component.get("dtend")
-            if dtstart_val:
-                event_dict["dtstart"] = dtstart_val.dt.isoformat()
-            if dtend_val:
-                event_dict["dtend"] = dtend_val.dt.isoformat()
+                dtstart_val = e.component.get("dtstart")
+                dtend_val = e.component.get("dtend")
+                if dtstart_val:
+                    event_dict["dtstart"] = dtstart_val.dt.isoformat()
+                if dtend_val:
+                    event_dict["dtend"] = dtend_val.dt.isoformat()
 
-            if e.component.get("rrule"):
-                event_dict["rrule"] = e.component["rrule"].to_ical().decode("utf-8")
-                log(f"Processing recurring event: {event_dict.get('summary')}")
-                log(f"Original dtstart: {event_dict.get('dtstart')}")
-                try:
-                    duration = (
-                        (dtend_val.dt - dtstart_val.dt)
-                        if dtstart_val and dtend_val
-                        else timedelta(hours=1)
-                    )
-                    log(f"Duration: {duration}")
-
-                    dtstart_dt = dtstart_val.dt
-                    if isinstance(dtstart_dt, date) and not isinstance(
-                        dtstart_dt, datetime
-                    ):
-                        log("All-day event detected")
-                        dtstart_dt = datetime.combine(
-                            dtstart_dt,
-                            datetime.min.time(),
-                            tzinfo=ZoneInfo(__user__["timezone"]),
+                if e.component.get("rrule"):
+                    event_dict["rrule"] = e.component["rrule"].to_ical().decode("utf-8")
+                    log(f"Processing recurring event: {event_dict.get('summary')}")
+                    log(f"Original dtstart: {event_dict.get('dtstart')}")
+                    try:
+                        duration = (
+                            (dtend_val.dt - dtstart_val.dt)
+                            if dtstart_val and dtend_val
+                            else timedelta(hours=1)
                         )
-                    elif dtstart_dt.tzinfo is None:
-                        log("Naive datetime detected")
-                        dtstart_dt = dtstart_dt.replace(
-                            tzinfo=ZoneInfo(__user__["timezone"])
-                        )
-                    else:
-                        log("TZ-aware datetime detected")
-                        dtstart_dt = dtstart_dt.astimezone(
-                            ZoneInfo(__user__["timezone"])
-                        )
+                        log(f"Duration: {duration}")
 
-                    log(f"RRULE: {event_dict['rrule']}")
-                    rrule_obj = rrulestr(event_dict["rrule"], dtstart=dtstart_dt)
-                    now = datetime.now(ZoneInfo(__user__["timezone"]))
-                    log(f"Now: {now}")
-                    next_occurrence = rrule_obj.after(now, inc=False)
+                        dtstart_dt = dtstart_val.dt
+                        if isinstance(dtstart_dt, date) and not isinstance(
+                            dtstart_dt, datetime
+                        ):
+                            log("All-day event detected")
+                            dtstart_dt = datetime.combine(
+                                dtstart_dt,
+                                datetime.min.time(),
+                                tzinfo=ZoneInfo(__user__["timezone"]),
+                            )
+                        elif dtstart_dt.tzinfo is None:
+                            log("Naive datetime detected")
+                            dtstart_dt = dtstart_dt.replace(
+                                tzinfo=ZoneInfo(__user__["timezone"])
+                            )
+                        else:
+                            log("TZ-aware datetime detected")
+                            dtstart_dt = dtstart_dt.astimezone(
+                                ZoneInfo(__user__["timezone"])
+                            )
 
-                    if next_occurrence:
-                        log(f"Next occurrence: {next_occurrence.isoformat()}")
-                        log(
-                            f"New dtstart: {event_dict['dtstart']} -> {next_occurrence}"
-                        )
-                        event_dict["dtstart"] = next_occurrence.isoformat()
-                        event_dict["dtend"] = (next_occurrence + duration).isoformat()
-                        log(f"New dtend: {event_dict['dtend']}")
-                    else:
-                        log("No future occurrence found")
-                except Exception as err:
-                    log(f"RRULE parsing failed: {err}")
-                    pass
+                        log(f"RRULE: {event_dict['rrule']}")
+                        rrule_obj = rrulestr(event_dict["rrule"], dtstart=dtstart_dt)
+                        now = datetime.now(ZoneInfo(__user__["timezone"]))
+                        log(f"Now: {now}")
+                        next_occurrence = rrule_obj.after(now, inc=False)
 
-            if len(e.component.alarms.times) > 0:
-                event_dict["alarms"] = [
-                    str(time.trigger) for time in e.component.alarms.times
-                ]
+                        if next_occurrence:
+                            log(f"Next occurrence: {next_occurrence.isoformat()}")
+                            log(
+                                f"New dtstart: {event_dict['dtstart']}"
+                                f" -> {next_occurrence}"
+                            )
+                            event_dict["dtstart"] = next_occurrence.isoformat()
+                            event_dict["dtend"] = (
+                                next_occurrence + duration
+                            ).isoformat()
+                            log(f"New dtend: {event_dict['dtend']}")
+                        else:
+                            log("No future occurrence found")
+                    except Exception as err:
+                        log(f"RRULE parsing failed: {err}")
+                        pass
 
-            event_data.append(event_dict)
+                if len(e.component.alarms.times) > 0:
+                    event_dict["alarms"] = [
+                        str(time.trigger) for time in e.component.alarms.times
+                    ]
 
-        return event_data
+                event_data.append(event_dict)
+
+            return event_data
+        finally:
+            await client.close()
 
     @tool_logger
     @caldav_safe
@@ -1302,22 +1337,25 @@ class Tools:
             raise Exception("must provide a summary or uid")
 
         client = await self.caldav_client
-        principal = await client.principal()
-        cal = await self._get_calendar(principal, calendar_name)
-        event = None
-        if uid:
-            event = await cal.event_by_uid(uid)
-        elif summary is not None:
-            matches = []
-            events = await cal.events()
-            for e in events:
-                c = e.component
-                if summary.strip() in c["summary"]:
-                    matches.append(c["uid"])
-            if len(matches) > 1:
-                raise Exception(f"multiple matches for summary {summary!r}")
-            elif len(matches) == 1:
-                event = await cal.event_by_uid(matches[0])
-        if not event:
-            raise NotFoundError(f"event not found for {summary!r}")
-        await event.delete()
+        try:
+            principal = await client.principal()
+            cal = await self._get_calendar(principal, calendar_name)
+            event = None
+            if uid:
+                event = await cal.event_by_uid(uid)
+            elif summary is not None:
+                matches = []
+                events = await cal.events()
+                for e in events:
+                    c = e.component
+                    if summary.strip() in c["summary"]:
+                        matches.append(c["uid"])
+                if len(matches) > 1:
+                    raise Exception(f"multiple matches for summary {summary!r}")
+                elif len(matches) == 1:
+                    event = await cal.event_by_uid(matches[0])
+            if not event:
+                raise NotFoundError(f"event not found for {summary!r}")
+            await event.delete()
+        finally:
+            await client.close()

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -3,13 +3,14 @@ title: owuinc
 author: soakedcardinal
 git_url: https://github.com/soakedcardinal/owuinc
 description: Manage files, tasks, and calendars via WebDAV and CalDAV.
-requirements: caldav,icalendar,webdavclient3
-version: 2.3.0
+requirements: caldav>=3.0.0,icalendar,aiowebdav2
+version: 2.4.0
 license: MIT
 """
 
 import fnmatch
 import functools
+import inspect
 import os
 import re
 import traceback
@@ -20,19 +21,21 @@ from io import BytesIO
 from typing import Any, Callable, List, Optional
 from zoneinfo import ZoneInfo
 
-from caldav.davclient import get_davclient
+from aiowebdav2 import Client as WebDAVClient
+from aiowebdav2.exceptions import (
+    ConnectionExceptionError,
+    LocalResourceNotFoundError,
+    NoConnectionError,
+    RemoteParentNotFoundError,
+    RemoteResourceNotFoundError,
+    ResourceLockedError,
+    WebDavError,
+)
+from caldav.aio import get_async_davclient
 from caldav.lib.error import NotFoundError
 from dateutil.rrule import rrulestr
 from icalendar import Alarm, Event
 from pydantic import BaseModel, Field
-from webdav3.client import Client
-from webdav3.exceptions import (
-    ConnectionException,
-    LocalResourceNotFound,
-    RemoteResourceNotFound,
-    ResourceLocked,
-    WebDavException,
-)
 
 DEBUG = False
 # DEBUG = True
@@ -70,27 +73,31 @@ def log_valves(valves):
 
 def tool_logger(func: Callable) -> Callable:
     @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
+    async def wrapper(self, *args, **kwargs):
         log_sep(func.__name__)
         log_valves(self.valves)
-        return func(self, *args, **kwargs)
+        result = func(self, *args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
 
     return wrapper
 
 
 def caldav_safe(func: Callable) -> Callable:
     @functools.wraps(func)
-    def wrapper(*args, **kwargs) -> dict:
+    async def wrapper(*args, **kwargs) -> dict:
         op = func.__name__
         try:
             result = func(*args, **kwargs)
+            if inspect.isawaitable(result):
+                result = await result
             response = {"result": "True"}
             if result is not None:
                 response["data"] = result
             return response
         except NotFoundError as e:
             log(f"{op}: {e}")
-            # Extract just the message, or fall back to string representation
             msg = e.args[0] if hasattr(e, "args") and e.args else str(e)
             return {"result": "False", "details": msg}
         except Exception as e:
@@ -105,33 +112,35 @@ def caldav_safe(func: Callable) -> Callable:
 
 def webdav_safe(func: Callable) -> Callable:
     @functools.wraps(func)
-    def wrapper(*args, **kwargs) -> dict:
+    async def wrapper(*args, **kwargs) -> dict:
         op = func.__name__
         try:
             result = func(*args, **kwargs)
+            if inspect.isawaitable(result):
+                result = await result
             response = {"result": "True"}
             if result is not None:
                 response["data"] = result
             return response
-        except RemoteResourceNotFound as e:
+        except (RemoteResourceNotFoundError, RemoteParentNotFoundError) as e:
             log_err(
                 f"{op}: resource not found - {e}\nTraceback: {traceback.format_exc()}"
             )
             return {"result": "False", "details": f"{op}: not found"}
-        except LocalResourceNotFound as e:
+        except LocalResourceNotFoundError as e:
             log_err(
                 f"{op}: local file not found - {e}\nTraceback: {traceback.format_exc()}"
             )
             return {"result": "False", "details": f"{op}: local file not found"}
-        except ResourceLocked as e:
+        except ResourceLockedError as e:
             log_err(f"{op}: resource locked - {e}\nTraceback: {traceback.format_exc()}")
             return {"result": "False", "details": f"{op}: resource locked"}
-        except ConnectionException as e:
+        except (ConnectionExceptionError, NoConnectionError) as e:
             log_err(
                 f"{op}: connection failed - {e}\nTraceback: {traceback.format_exc()}"
             )
             return {"result": "False", "details": f"{op}: connection failed"}
-        except WebDavException as e:
+        except WebDavError as e:
             log_err(f"{op}: WebDAV error - {e}\nTraceback: {traceback.format_exc()}")
             return {"result": "False", "details": f"{op}: {str(e)}"}
         except ValueError as e:
@@ -147,20 +156,14 @@ def webdav_safe(func: Callable) -> Callable:
     return wrapper
 
 
-def ensure_sandbox(func: Callable) -> Callable:
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        sandbox = self.valves.SANDBOX_DIR.strip().rstrip("/")
-        if sandbox:
-            try:
-                log(f"checking sandbox dir exists: {sandbox!r}")
-                self.webdav_client.list(sandbox + "/")
-            except RemoteResourceNotFound:
-                log(f"sandbox dir not found, creating: {sandbox!r}")
-                self.webdav_client.mkdir(sandbox)
-        return func(self, *args, **kwargs)
+def _webdav_path(p: str) -> str:
+    """Ensure path has leading / for aiowebdav2."""
+    return p if p.startswith("/") else "/" + p
 
-    return wrapper
+
+def _strip_leading_slash(p: str) -> str:
+    """Strip leading / from aiowebdav2 paths to match webdavclient3 format."""
+    return p.lstrip("/") if p else p
 
 
 def validate_path(path, valves):
@@ -196,32 +199,25 @@ def validate_path(path, valves):
     """
     prefix = valves.SANDBOX_DIR.strip().rstrip("/") + "/"
 
-    # Empty path returns sandbox root
     if not path:
         return prefix
 
     path = path.strip()
 
-    # Decode URL-encoded characters (e.g., %2e%2e -> ..) to catch encoded traversal
     prev = None
     while prev != path:
         prev = path
         path = urllib.parse.unquote(path)
 
-    # BLOCKED: Path traversal attempts (catches all forms: ../, foo/../, etc.)
     if ".." in path:
         raise Exception("Invalid Path: traversal not allowed")
 
-    # Root indicators map to sandbox root
     if path in ("", ".", "/"):
         return prefix
 
-    # Strip leading slash - treat as relative to sandbox (not system root)
-    # This allows natural "/" usage while keeping operations confined
     if path.startswith("/"):
         path = path.lstrip("/")
 
-    # Build full path and verify it stays within sandbox
     full_path = prefix + os.path.normpath(path)
     if full_path.startswith(prefix):
         return full_path
@@ -308,13 +304,12 @@ class Tools:
         wd_user = self.valves.WEBDAV_USERNAME
         url = f"{base}/remote.php/dav/files/{wd_user}/"
         log(f"create webdav_client with url={url!r}")
-        data = {
-            "webdav_hostname": url,
-            "webdav_login": self.valves.NEXTCLOUD_USERNAME,
-            "webdav_password": self.valves.NEXTCLOUD_APP_PASSWORD,
-        }
         try:
-            return Client(data)
+            return WebDAVClient(
+                url,
+                self.valves.NEXTCLOUD_USERNAME,
+                self.valves.NEXTCLOUD_APP_PASSWORD,
+            )
         except Exception as e:
             log_err(f"failed to create webdav_client: {type(e).__name__}: {e}")
             raise
@@ -325,14 +320,13 @@ class Tools:
         url = f"{base}/remote.php/dav"
         log(f"creating new caldav_client with url={url!r}")
         try:
-            caldav_client = get_davclient(
+            return get_async_davclient(
                 username=self.valves.NEXTCLOUD_USERNAME,
                 password=self.valves.NEXTCLOUD_APP_PASSWORD,
                 url=url,
                 features="nextcloud",
                 enable_rfc6764=False,
             )
-            return caldav_client
         except Exception as e:
             log_err(
                 f"Failed to create caldav_client: \
@@ -340,11 +334,42 @@ class Tools:
             )
             raise
 
+    async def _get_calendar(self, principal, calendar_name: str):
+        """Get a calendar by name, working around caldav.aio's broken calendar().
+
+        caldav.aio.CalendarSet.calendar(name=...) calls get_calendars() and
+        get_display_name() internally without awaiting them, which fails for
+        async clients. This helper properly awaits all async calls.
+        """
+        calendars = await principal.get_calendars()
+        for cal in calendars:
+            display_name = await cal.get_display_name()
+            if display_name == calendar_name:
+                return cal
+        raise NotFoundError(f"No calendar with name {calendar_name!r} found")
+
+    async def _ensure_sandbox(self, client):
+        """Ensure sandbox directory exists.
+
+        Must be called within a webdav client context.
+        """
+        sandbox = self.valves.SANDBOX_DIR.strip().rstrip("/")
+        if sandbox:
+            try:
+                log(f"checking sandbox dir exists: {sandbox!r}")
+                await client.list_files(_webdav_path(sandbox + "/"))
+            except RemoteResourceNotFoundError:
+                log(f"sandbox dir not found, creating: {sandbox!r}")
+                await client.mkdir(_webdav_path(sandbox))
+
     @tool_logger
     @caldav_safe
-    def get_calendars(self) -> list[str]:
+    async def get_calendars(self) -> list[str]:
         """Retrieve available calendars"""
-        available = [c.name for c in self.caldav_client.principal().calendars()]
+        client = await self.caldav_client
+        principal = await client.principal()
+        calendars = await principal.get_calendars()
+        available = [await c.get_display_name() for c in calendars]
         log(f"found {len(available)} calendars: {available!r}")
 
         return [
@@ -355,9 +380,12 @@ class Tools:
 
     @tool_logger
     @caldav_safe
-    def get_task_lists(self) -> list[str]:
+    async def get_task_lists(self) -> list[str]:
         """Retrieve available task lists"""
-        available = [c.name for c in self.caldav_client.principal().calendars()]
+        client = await self.caldav_client
+        principal = await client.principal()
+        calendars = await principal.get_calendars()
+        available = [await c.get_display_name() for c in calendars]
         log(f"found {len(available)} task lists: {available!r}")
 
         return [
@@ -367,31 +395,41 @@ class Tools:
         ]
 
     @tool_logger
-    @ensure_sandbox
     @webdav_safe
-    def mkdir(
+    async def mkdir(
         self,
         path: str,
     ) -> None:
         """Create new directory"""
-        self.webdav_client.mkdir(validate_path(path, self.valves))
+        client = self.webdav_client
+        try:
+            await self._ensure_sandbox(client)
+            await client.mkdir(_webdav_path(validate_path(path, self.valves)))
+        finally:
+            await client.close()
 
     @tool_logger
-    @ensure_sandbox
     @webdav_safe
-    def ls(self, path: str | None = None) -> list[str]:
+    async def ls(self, path: str | None = None) -> list[str]:
         """List files and directories"""
-        p = validate_path(path, self.valves)
-        prefix = f"{self.valves.SANDBOX_DIR.strip().rstrip('/')}/"
-        paths = self.webdav_client.list(p)
-        parent = p.strip(prefix).strip("/")
-        result_list = [p for p in paths if p != prefix and p.strip("/") != parent]
-        return result_list
+        client = self.webdav_client
+        try:
+            await self._ensure_sandbox(client)
+            p = validate_path(path, self.valves)
+            prefix = f"{self.valves.SANDBOX_DIR.strip().rstrip('/')}/"
+            raw_paths = await client.list_files(_webdav_path(p))
+            paths = [_strip_leading_slash(rp) for rp in raw_paths]
+            parent = p.strip(prefix).strip("/")
+            result_list = [
+                item for item in paths if item != prefix and item.strip("/") != parent
+            ]
+            return result_list
+        finally:
+            await client.close()
 
     @tool_logger
-    @ensure_sandbox
     @webdav_safe
-    def glob(
+    async def glob(
         self,
         pattern: str,
         path: Optional[str] = None,
@@ -408,82 +446,83 @@ class Tools:
         Returns:
             matching file paths sorted by modification time (newest last)
         """
-        target_dir = validate_path(path if path else "", self.valves)
-
-        log(f"glob: pattern={pattern}, target_dir={target_dir}")
-
-        # Determine recursion depth from pattern
-        pattern_parts = pattern.split("/")
-        is_recursive = "**" in pattern_parts or (
-            len(pattern_parts) == 1 and "*" in pattern_parts[0]
-        )
-
-        log(f"glob: is_recursive={is_recursive}")
-
-        # Fetch files from WebDAV
-        all_files = self.webdav_client.list(
-            target_dir, get_info=True, recursive=is_recursive
-        )
-
-        log(f"glob: fetched {len(all_files)} items")
-
-        # Filter to files only (exclude directories)
-        files_only = [f for f in all_files if not f.get("isdir", False)]
-
-        log(f"glob: {len(files_only)} files after filtering dirs")
-
-        # Simple brace expansion (single-level only: {a,b} → a, b)
-        patterns_to_match = [pattern]
-        if "{" in pattern and "}" in pattern:
-            start = pattern.find("{")
-            end = pattern.find("}", start)
-            if end != -1:
-                prefix, suffix = pattern[:start], pattern[end + 1 :]
-                alternatives = pattern[start + 1 : end].split(",")
-                patterns_to_match = [prefix + alt + suffix for alt in alternatives]
-
-        # Filter files using fnmatch against expanded patterns
-        matched = []
-        for file_info in files_only:
-            # Get filename from path (webdav returns 'path' not 'name')
-            full_path = file_info.get("path", "")
-            filename = os.path.basename(full_path)
-
-            log(f"glob: checking {filename} against patterns")
-
-            for pat in patterns_to_match:
-                # Extract just the filename part of pattern (after last /)
-                pattern_name = pat.split("/")[-1] if "/" in pat else pat
-                if fnmatch.fnmatch(filename, pattern_name):
-                    log(f"glob: matched {filename}")
-                    matched.append(file_info)
-                    break
-
-        # Sort by modification time (newest last)
+        client = self.webdav_client
         try:
-            matched.sort(key=lambda x: x.get("modified", ""))
-        except Exception as e:
-            log(f"glob: sort error - {e}")
+            await self._ensure_sandbox(client)
+            target_dir = validate_path(path if path else "", self.valves)
 
-        # Strip full WebDAV path and return relative paths from sandbox
-        sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
-        result = []
-        for f in matched:
-            full_path = f.get("path", "")
-            # Extract just the relative path after sandbox directory
-            if sandbox_prefix in full_path:
-                rel_path = full_path.split(sandbox_prefix, 1)[1]
-            else:
-                rel_path = os.path.basename(full_path)
-            result.append(rel_path)
+            log(f"glob: pattern={pattern}, target_dir={target_dir}")
 
-        log(f"glob: returning {len(result)} matches")
-        return result
+            pattern_parts = pattern.split("/")
+            is_recursive = "**" in pattern_parts or (
+                len(pattern_parts) == 1 and "*" in pattern_parts[0]
+            )
+
+            log(f"glob: is_recursive={is_recursive}")
+
+            all_files = await client.list_with_infos(
+                _webdav_path(target_dir), recursive=is_recursive
+            )
+
+            log(f"glob: fetched {len(all_files)} items")
+
+            files_only = [
+                f for f in all_files if str(f.get("isdir", "False")).lower() != "true"
+            ]
+
+            log(f"glob: {len(files_only)} files after filtering dirs")
+
+            patterns_to_match = [pattern]
+            if "{" in pattern and "}" in pattern:
+                start = pattern.find("{")
+                end = pattern.find("}", start)
+                if end != -1:
+                    prefix, suffix = pattern[:start], pattern[end + 1 :]
+                    alternatives = pattern[start + 1 : end].split(",")
+                    patterns_to_match = [prefix + alt + suffix for alt in alternatives]
+
+            matched = []
+            for file_info in files_only:
+                full_path = _strip_leading_slash(file_info.get("path", ""))
+                filename = os.path.basename(full_path)
+
+                log(f"glob: checking {filename} against patterns")
+
+                for pat in patterns_to_match:
+                    pattern_name = pat.split("/")[-1] if "/" in pat else pat
+                    if fnmatch.fnmatch(filename, pattern_name):
+                        log(f"glob: matched {filename}")
+                        matched.append(
+                            {
+                                "path": full_path,
+                                "modified": file_info.get("modified", ""),
+                            }
+                        )
+                        break
+
+            try:
+                matched.sort(key=lambda x: x.get("modified", ""))
+            except Exception as e:
+                log(f"glob: sort error - {e}")
+
+            sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
+            result = []
+            for f in matched:
+                full_path = f["path"]
+                if sandbox_prefix in full_path:
+                    rel_path = full_path.split(sandbox_prefix, 1)[1]
+                else:
+                    rel_path = os.path.basename(full_path)
+                result.append(rel_path)
+
+            log(f"glob: returning {len(result)} matches")
+            return result
+        finally:
+            await client.close()
 
     @tool_logger
-    @ensure_sandbox
     @webdav_safe
-    def grep(
+    async def grep(
         self,
         pattern: str,
         path: Optional[str] = None,
@@ -496,96 +535,102 @@ class Tools:
             path: The directory to search in. Defaults to root.
             include: File pattern to include (e.g., "*.py", "*.{ts,tsx}")
         """
-        target_dir = validate_path(path if path else "", self.valves)
-
-        log(f"grep: pattern={pattern!r}, target_dir={target_dir}, include={include!r}")
-
-        # Fetch items recursively with get_info to distinguish dirs/files
-        all_items = self.webdav_client.list(target_dir, get_info=True, recursive=True)
-        if not all_items:
-            return []
-
-        log(f"grep: fetched {len(all_items)} items")
-
-        # Filter to files only and extract relative paths
-        file_list = [
-            item.get("path", item) for item in all_items if not item.get("isdir", False)
-        ]
-
-        log(f"grep: {len(file_list)} files after filtering directories")
-
-        # Simple brace expansion (single-level only: {a,b} → a, b)
-        patterns_to_match = [include] if include else []
-        if include and "{" in include and "}" in include:
-            start = include.find("{")
-            end = include.find("}", start)
-            if end != -1:
-                prefix, suffix = include[:start], include[end + 1 :]
-                alternatives = include[start + 1 : end].split(",")
-                patterns_to_match = [prefix + alt + suffix for alt in alternatives]
-
-        # Compile regex pattern
+        client = self.webdav_client
         try:
-            compiled_regex = re.compile(pattern)
-        except re.error as e:
-            raise ValueError(f"Invalid regex pattern: {e}")
+            await self._ensure_sandbox(client)
+            target_dir = validate_path(path if path else "", self.valves)
 
-        # Search each file
-        results = []
-        for full_path in file_list:
-            sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
-            rel_path = (
-                full_path.split(sandbox_prefix, 1)[1]
-                if sandbox_prefix in full_path
-                else os.path.basename(full_path)
+            log(
+                f"grep: pattern={pattern!r}, "
+                f"target_dir={target_dir}, include={include!r}"
             )
-            filename = os.path.basename(rel_path)
 
-            # Check include pattern if specified
-            if patterns_to_match:
-                matched = False
-                for pat in patterns_to_match:
-                    pattern_name = pat.split("/")[-1] if "/" in pat else pat
-                    if fnmatch.fnmatch(filename, pattern_name):
-                        matched = True
-                        break
-                if not matched:
-                    continue
+            all_items = await client.list_with_infos(
+                _webdav_path(target_dir), recursive=True
+            )
+            if not all_items:
+                return []
 
-            webdav_path = validate_path(rel_path, self.valves)
-            log(f"grep: searching {rel_path}")
+            log(f"grep: fetched {len(all_items)} items")
+
+            file_list = [
+                _strip_leading_slash(item.get("path", item))
+                for item in all_items
+                if str(item.get("isdir", "False")).lower() != "true"
+            ]
+
+            log(f"grep: {len(file_list)} files after filtering directories")
+
+            patterns_to_match = [include] if include else []
+            if include and "{" in include and "}" in include:
+                start = include.find("{")
+                end = include.find("}", start)
+                if end != -1:
+                    prefix, suffix = include[:start], include[end + 1 :]
+                    alternatives = include[start + 1 : end].split(",")
+                    patterns_to_match = [prefix + alt + suffix for alt in alternatives]
 
             try:
-                buf = BytesIO()
-                self.webdav_client.resource(webdav_path).write_to(buf)
-                content = buf.getvalue().decode("utf-8")
+                compiled_regex = re.compile(pattern)
+            except re.error as e:
+                raise ValueError(f"Invalid regex pattern: {e}")
 
-                log(
-                    f"grep: read {len(c := content)} bytes, {len(c.splitlines())} lines"
+            results = []
+            for full_path in file_list:
+                sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
+                rel_path = (
+                    full_path.split(sandbox_prefix, 1)[1]
+                    if sandbox_prefix in full_path
+                    else os.path.basename(full_path)
                 )
+                filename = os.path.basename(rel_path)
 
-                for line_num, line in enumerate(content.splitlines(), start=1):
-                    if compiled_regex.search(line):
-                        results.append(
-                            {
-                                "file": rel_path,
-                                "line": line_num,
-                                "content": line.strip(),
-                            }
-                        )
+                if patterns_to_match:
+                    matched = False
+                    for pat in patterns_to_match:
+                        pattern_name = pat.split("/")[-1] if "/" in pat else pat
+                        if fnmatch.fnmatch(filename, pattern_name):
+                            matched = True
+                            break
+                    if not matched:
+                        continue
 
-            except Exception as e:
-                log(f"grep: error reading {rel_path}: {e}")
-                continue
+                webdav_path = _webdav_path(validate_path(rel_path, self.valves))
+                log(f"grep: searching {rel_path}")
 
-        results.sort(key=lambda x: (x["file"], x["line"]))
-        log(f"grep: found {len(results)} matches")
-        return results
+                try:
+                    buf = BytesIO()
+                    await client.resource(webdav_path).read_from(buf)
+                    content = buf.getvalue().decode("utf-8")
+
+                    log(
+                        f"grep: read {len(c := content)} bytes, "
+                        f"{len(c.splitlines())} lines"
+                    )
+
+                    for line_num, line in enumerate(content.splitlines(), start=1):
+                        if compiled_regex.search(line):
+                            results.append(
+                                {
+                                    "file": rel_path,
+                                    "line": line_num,
+                                    "content": line.strip(),
+                                }
+                            )
+
+                except Exception as e:
+                    log(f"grep: error reading {rel_path}: {e}")
+                    continue
+
+            results.sort(key=lambda x: (x["file"], x["line"]))
+            log(f"grep: found {len(results)} matches")
+            return results
+        finally:
+            await client.close()
 
     @tool_logger
-    @ensure_sandbox
     @webdav_safe
-    def write_file(
+    async def write_file(
         self,
         path: str,
         content: Optional[str] = None,
@@ -593,14 +638,18 @@ class Tools:
         """Write to a file, overwriting existing content"""
         if content is None:
             content = ""
-        self.webdav_client.resource(validate_path(path, self.valves)).read_from(
-            BytesIO(content.encode("utf-8"))
-        )
+        client = self.webdav_client
+        try:
+            await self._ensure_sandbox(client)
+            await client.resource(
+                _webdav_path(validate_path(path, self.valves))
+            ).write_to(BytesIO(content.encode("utf-8")))
+        finally:
+            await client.close()
 
     @tool_logger
-    @ensure_sandbox
     @webdav_safe
-    def read(
+    async def read(
         self,
         path: str,
         offset: Optional[int] = None,
@@ -622,24 +671,30 @@ class Tools:
         if limit is not None and limit <= 0:
             raise ValueError(f"limit must be > 0, got {limit}")
 
-        buf = BytesIO()
-        self.webdav_client.resource(validate_path(path, self.valves)).write_to(buf)
-        content = buf.getvalue().decode("utf-8")
-        lines = content.splitlines()
+        client = self.webdav_client
+        try:
+            await self._ensure_sandbox(client)
+            buf = BytesIO()
+            await client.resource(
+                _webdav_path(validate_path(path, self.valves))
+            ).read_from(buf)
+            content = buf.getvalue().decode("utf-8")
+            lines = content.splitlines()
 
-        if offset is not None:
-            start = max(0, offset - 1)
-            lines = lines[start:]
+            if offset is not None:
+                start = max(0, offset - 1)
+                lines = lines[start:]
 
-        if limit is not None:
-            lines = lines[:limit]
+            if limit is not None:
+                lines = lines[:limit]
 
-        return "\n".join(lines)
+            return "\n".join(lines)
+        finally:
+            await client.close()
 
     @tool_logger
-    @ensure_sandbox
     @webdav_safe
-    def append_file(
+    async def append_file(
         self,
         path: str,
         content: Optional[str] = None,
@@ -647,19 +702,24 @@ class Tools:
         """Append content to file, creating it if it does not exist"""
         if content is None:
             content = ""
-        res = self.webdav_client.resource(validate_path(path, self.valves))
+        client = self.webdav_client
         try:
-            buf = BytesIO()
-            res.write_to(buf)
-            existing = buf.getvalue().decode("utf-8")
-        except RemoteResourceNotFound:
-            existing = ""
-        res.read_from(BytesIO((existing + content).encode("utf-8")))
+            await self._ensure_sandbox(client)
+            res_path = _webdav_path(validate_path(path, self.valves))
+            res = client.resource(res_path)
+            try:
+                buf = BytesIO()
+                await res.read_from(buf)
+                existing = buf.getvalue().decode("utf-8")
+            except RemoteResourceNotFoundError:
+                existing = ""
+            await res.write_to(BytesIO((existing + content).encode("utf-8")))
+        finally:
+            await client.close()
 
     @tool_logger
-    @ensure_sandbox
     @webdav_safe
-    def edit(
+    async def edit(
         self,
         file_path: str,
         old_string: str,
@@ -682,74 +742,98 @@ class Tools:
         if old_string == new_string:
             raise ValueError("old_string and new_string must be different")
 
-        buf = BytesIO()
-        self.webdav_client.resource(validate_path(file_path, self.valves)).write_to(buf)
-        content = buf.getvalue().decode("utf-8")
+        client = self.webdav_client
+        try:
+            await self._ensure_sandbox(client)
+            res_path = _webdav_path(validate_path(file_path, self.valves))
+            buf = BytesIO()
+            await client.resource(res_path).read_from(buf)
+            content = buf.getvalue().decode("utf-8")
 
-        count = content.count(old_string)
+            count = content.count(old_string)
 
-        if count == 0:
-            raise ValueError("String not found")
+            if count == 0:
+                raise ValueError("String not found")
 
-        if count > 1 and not replace_all:
-            raise ValueError(f"Found {count} matches, but replace_all is false")
+            if count > 1 and not replace_all:
+                raise ValueError(f"Found {count} matches, but replace_all is false")
 
-        replacement_count = 1 if not replace_all else -1
-        modified_content = content.replace(old_string, new_string, replacement_count)
+            replacement_count = 1 if not replace_all else -1
+            modified_content = content.replace(
+                old_string, new_string, replacement_count
+            )
 
-        self.webdav_client.resource(validate_path(file_path, self.valves)).read_from(
-            BytesIO(modified_content.encode("utf-8"))
-        )
+            await client.resource(res_path).write_to(
+                BytesIO(modified_content.encode("utf-8"))
+            )
 
-        return {"result": "True"}
+            return {"result": "True"}
+        finally:
+            await client.close()
 
     @tool_logger
-    @ensure_sandbox
     @webdav_safe
-    def rm(self, paths: list[str]) -> None:
+    async def rm(self, paths: list[str]) -> None:
         """Deletes files/directories"""
-        C = self.webdav_client
-        for p in paths:
-            C.clean(validate_path(p, self.valves))
+        client = self.webdav_client
+        try:
+            await self._ensure_sandbox(client)
+            for p in paths:
+                await client.clean(_webdav_path(validate_path(p, self.valves)))
+        finally:
+            await client.close()
 
     @tool_logger
-    @ensure_sandbox
     @webdav_safe
-    def mv(
+    async def mv(
         self,
         src: str,
         dst: str,
     ) -> None:
         """Move/rename a file or directory"""
-        self.webdav_client.move(
-            remote_path_from=validate_path(src, self.valves),
-            remote_path_to=validate_path(dst, self.valves),
-        )
+        client = self.webdav_client
+        try:
+            await self._ensure_sandbox(client)
+            await client.move(
+                remote_path_from=_webdav_path(validate_path(src, self.valves)),
+                remote_path_to=_webdav_path(validate_path(dst, self.valves)),
+            )
+        finally:
+            await client.close()
 
     @tool_logger
-    @ensure_sandbox
     @webdav_safe
-    def cp(
+    async def cp(
         self,
         src: str,
         dst: str,
     ) -> None:
         """Copy a file or directory."""
-        self.webdav_client.copy(
-            remote_path_from=validate_path(src, self.valves),
-            remote_path_to=validate_path(dst, self.valves),
-        )
+        client = self.webdav_client
+        try:
+            await self._ensure_sandbox(client)
+            await client.copy(
+                remote_path_from=_webdav_path(validate_path(src, self.valves)),
+                remote_path_to=_webdav_path(validate_path(dst, self.valves)),
+            )
+        finally:
+            await client.close()
 
     @tool_logger
     @caldav_safe
-    def get_tasks(self, list_name: str | None = None) -> list[dict] | Any:
+    async def get_tasks(self, list_name: str | None = None) -> list[dict] | Any:
         """Retrieve task from specified list"""
         list_name = list_name or self.valves.DEFAULT_TASK_LIST
         if not is_whitelisted(self.valves.TASK_LIST_WHITELIST, list_name):
             raise Exception(f"{list_name!r} not whitelisted")
 
+        client = await self.caldav_client
+        principal = await client.principal()
+        cal = await self._get_calendar(principal, list_name)
+        todos = await cal.todos()
+
         task_map: dict[str, dict] = {}
-        for todo in self.caldav_client.principal().calendar(name=list_name).todos():
+        for todo in todos:
             task_map[todo.component["uid"]] = {
                 key: todo.component.get(key)
                 for key in [
@@ -791,7 +875,7 @@ class Tools:
 
     @tool_logger
     @caldav_safe
-    def edit_task(
+    async def edit_task(
         self,
         summary: str | None = None,
         uid: str | None = None,
@@ -811,19 +895,22 @@ class Tools:
 
         if not (summary or uid):
             raise Exception("must specify summary or uid of task to edit")
-        cal = self.caldav_client.principal().calendar(name=list_name)
+        client = await self.caldav_client
+        principal = await client.principal()
+        cal = await self._get_calendar(principal, list_name)
         todo = None
         if uid:
-            todo = cal.todo_by_uid(uid)
+            todo = await cal.todo_by_uid(uid)
         elif summary is not None:
             matches = []
-            for todo in cal.todos():
+            todos = await cal.todos()
+            for todo in todos:
                 if summary.strip() in todo.component["summary"]:
                     matches.append(todo.component["uid"])
             if len(matches) > 1:
                 raise Exception(f"Multiple matches for {summary!r}: {matches}")
             elif len(matches) == 1:
-                todo = cal.todo_by_uid(matches[0])
+                todo = await cal.todo_by_uid(matches[0])
         if not todo:
             raise Exception("task not found")
         if new_summary:
@@ -840,11 +927,11 @@ class Tools:
             todo.component["url"] = new_url
         if new_related_to:
             todo.component["related-to"] = new_related_to
-        todo.save()
+        await todo.save()
 
     @tool_logger
     @caldav_safe
-    def delete_task(
+    async def delete_task(
         self,
         summary: Optional[str] = None,
         uid: Optional[str] = None,
@@ -857,26 +944,29 @@ class Tools:
 
         if not (summary or uid):
             raise Exception("must specify summary or uid of task to edit")
-        cal = self.caldav_client.principal().calendar(name=list_name)
+        client = await self.caldav_client
+        principal = await client.principal()
+        cal = await self._get_calendar(principal, list_name)
         todo = None
         if uid:
-            todo = cal.todo_by_uid(uid)
+            todo = await cal.todo_by_uid(uid)
         elif summary is not None:
             matches = []
-            for todo in cal.todos():
+            todos = await cal.todos()
+            for todo in todos:
                 if summary.strip() in todo.component["summary"]:
                     matches.append(todo.component["uid"])
             if len(matches) > 1:
                 raise Exception(f"Error: Multiple matches for {summary!r}: {matches}")
             elif len(matches) == 1:
-                todo = cal.todo_by_uid(matches[0])
+                todo = await cal.todo_by_uid(matches[0])
         if not todo:
             raise Exception("Error: task not found")
-        todo.delete()
+        await todo.delete()
 
     @tool_logger
     @caldav_safe
-    def create_calendar_event(
+    async def create_calendar_event(
         self,
         summary: str,
         calendar_name: str | None = None,
@@ -895,13 +985,15 @@ class Tools:
 
         zi = ZoneInfo(__user__["timezone"])
         now = datetime.now(zi).replace(second=0, microsecond=0)
-        cal = self.caldav_client.principal().calendar(name=calendar_name)
+        client = await self.caldav_client
+        principal = await client.principal()
+        cal = await self._get_calendar(principal, calendar_name)
 
         uid = str(uuid.uuid4())
         e = Event()
         e.add("uid", uid)
         e.add("summary", summary)
-        e.add("dtstamp", now)  # required
+        e.add("dtstamp", now)
         e.add("created", now)
         e.add("last-modified", now)
 
@@ -934,12 +1026,12 @@ class Tools:
                 a.add("trigger", timedelta(minutes=-r.get("minutes")))
                 a.add("description", summary)
                 e.add_component(a)
-        cal.save_event(ical=e)
+        await cal.save_event(ical=e)
         return uid
 
     @tool_logger
     @caldav_safe
-    def add_task(
+    async def add_task(
         self,
         summary: str,
         list_name: str | None = None,
@@ -955,12 +1047,15 @@ class Tools:
             raise Exception(f"{list_name!r} not whitelisted")
 
         uid = str(uuid.uuid4())
-        p = self.caldav_client.principal()
-        available_lists = [c.name for c in p.calendars()]
+        client = await self.caldav_client
+        principal = await client.principal()
+        calendars = await principal.get_calendars()
+        available_lists = [await c.get_display_name() for c in calendars]
         if list_name not in available_lists:
             log_err("invalid task list")
             raise Exception("invalid task list")
-        p.calendar(name=list_name).save_todo(
+        cal = await self._get_calendar(principal, list_name)
+        await cal.save_todo(
             uid=uid,
             summary=summary,
             priority=priority,
@@ -974,7 +1069,7 @@ class Tools:
     # TODO this duplicates edit task should be a wrapper
     @tool_logger
     @caldav_safe
-    def complete_task(
+    async def complete_task(
         self,
         summary: Optional[str] = None,
         uid: Optional[str] = None,
@@ -985,12 +1080,15 @@ class Tools:
         if not is_whitelisted(self.valves.TASK_LIST_WHITELIST, list_name):
             raise Exception(f"{list_name!r} not whitelisted")
 
-        cal = self.caldav_client.principal().calendar(name=list_name)
+        client = await self.caldav_client
+        principal = await client.principal()
+        cal = await self._get_calendar(principal, list_name)
         if uid:
-            todo = cal.todo_by_uid(uid)
+            todo = await cal.todo_by_uid(uid)
         elif summary is not None:
             matches = []
-            for t in cal.todos():
+            todos = await cal.todos()
+            for t in todos:
                 if summary.strip() in t.component["summary"]:
                     matches.append(t)
             if len(matches) > 1:
@@ -1001,11 +1099,11 @@ class Tools:
                 )
             todo = matches[0]
         todo.component["status"] = "COMPLETED"
-        todo.save()
+        await todo.save()
 
     @tool_logger
     @caldav_safe
-    def edit_calendar_event(
+    async def edit_calendar_event(
         self,
         __user__: dict = {},
         summary: Optional[str] = None,
@@ -1029,20 +1127,23 @@ class Tools:
 
         tz = __user__["timezone"]
         zi = ZoneInfo(tz)
-        cal = self.caldav_client.principal().calendar(name=calendar_name)
+        client = await self.caldav_client
+        principal = await client.principal()
+        cal = await self._get_calendar(principal, calendar_name)
 
         e = None
         if uid:
-            e = cal.event_by_uid(uid)
+            e = await cal.event_by_uid(uid)
         elif summary is not None:
             matches = []
-            for e in cal.events():
+            events = await cal.events()
+            for e in events:
                 if summary.strip() in e.component["summary"]:
                     matches.append(e.component["uid"])
             if len(matches) > 1:
                 raise Exception("Error: multiple matches")
             elif len(matches) == 1:
-                e = cal.event_by_uid(matches[0])
+                e = await cal.event_by_uid(matches[0])
         if not e:
             raise Exception("Error: event not found")
 
@@ -1065,24 +1166,22 @@ class Tools:
         if new_rrule:
             e.component["rrule"] = new_rrule
         if new_alarms:
-            # remove existing
             valarm_subs = [
                 sub for sub in e.component.subcomponents if sub.name == "VALARM"
             ]
-            for sub in valarm_subs[:]:  # prevent index shifting
+            for sub in valarm_subs[:]:
                 e.component.subcomponents.remove(sub)
-            # add new
             for reminder in parse_reminders(new_alarms):
                 a = Alarm()
                 a.add("action", "DISPLAY")
                 a.add("trigger", timedelta(minutes=-reminder.get("minutes")))
                 a.add("description", e.component["summary"])
                 e.component.add_component(a)
-        e.save()
+        await e.save()
 
     @tool_logger
     @caldav_safe
-    def get_calendar_events(
+    async def get_calendar_events(
         self,
         calendar_name: str | None = None,
         __user__: dict = {},
@@ -1092,20 +1191,19 @@ class Tools:
         if not is_whitelisted(self.valves.CALENDAR_WHITELIST, calendar_name):
             raise Exception(f"{calendar_name!r} not in whitelist")
 
-        # Query future events (expand=False for token efficiency)
         event_data = []
-        for e in (
-            self.caldav_client.principal()
-            .calendar(name=calendar_name)
-            .search(
-                start=datetime.now(ZoneInfo(__user__["timezone"])),
-                expand=False,
-                event=True,
-            )
-        ):
+        client = await self.caldav_client
+        principal = await client.principal()
+        cal = await self._get_calendar(principal, calendar_name)
+        events = await cal.search(
+            start=datetime.now(ZoneInfo(__user__["timezone"])),
+            expand=False,
+            event=True,
+        )
+
+        for e in events:
             event_dict = {}
 
-            # Copy standard event fields
             for field in [
                 "uid",
                 "summary",
@@ -1118,7 +1216,6 @@ class Tools:
                 if val := e.component.get(field):
                     event_dict[field] = val
 
-            # Extract date/time values (keep as objects for duration calculation)
             dtstart_val = e.component.get("dtstart")
             dtend_val = e.component.get("dtend")
             if dtstart_val:
@@ -1126,13 +1223,11 @@ class Tools:
             if dtend_val:
                 event_dict["dtend"] = dtend_val.dt.isoformat()
 
-            # Handle recurring events: calculate next occurrence after "now"
             if e.component.get("rrule"):
                 event_dict["rrule"] = e.component["rrule"].to_ical().decode("utf-8")
                 log(f"Processing recurring event: {event_dict.get('summary')}")
                 log(f"Original dtstart: {event_dict.get('dtstart')}")
                 try:
-                    # Calculate original duration
                     duration = (
                         (dtend_val.dt - dtstart_val.dt)
                         if dtstart_val and dtend_val
@@ -1140,8 +1235,6 @@ class Tools:
                     )
                     log(f"Duration: {duration}")
 
-                    # Normalize dtstart to user's timezone for consistent comparison
-                    # Handle all-day events (date objects) vs datetime events
                     dtstart_dt = dtstart_val.dt
                     if isinstance(dtstart_dt, date) and not isinstance(
                         dtstart_dt, datetime
@@ -1163,17 +1256,17 @@ class Tools:
                             ZoneInfo(__user__["timezone"])
                         )
 
-                    # Parse RRULE and find next occurrence
                     log(f"RRULE: {event_dict['rrule']}")
                     rrule_obj = rrulestr(event_dict["rrule"], dtstart=dtstart_dt)
                     now = datetime.now(ZoneInfo(__user__["timezone"]))
                     log(f"Now: {now}")
                     next_occurrence = rrule_obj.after(now, inc=False)
 
-                    # Overwrite dates with next occurrence (preserves duration)
                     if next_occurrence:
                         log(f"Next occurrence: {next_occurrence.isoformat()}")
-                        log(f"New dtstart: {event_dict['dtstart']} → {next_occurrence}")
+                        log(
+                            f"New dtstart: {event_dict['dtstart']} -> {next_occurrence}"
+                        )
                         event_dict["dtstart"] = next_occurrence.isoformat()
                         event_dict["dtend"] = (next_occurrence + duration).isoformat()
                         log(f"New dtend: {event_dict['dtend']}")
@@ -1183,7 +1276,6 @@ class Tools:
                     log(f"RRULE parsing failed: {err}")
                     pass
 
-            # Include alarms if present
             if len(e.component.alarms.times) > 0:
                 event_dict["alarms"] = [
                     str(time.trigger) for time in e.component.alarms.times
@@ -1195,7 +1287,7 @@ class Tools:
 
     @tool_logger
     @caldav_safe
-    def delete_calendar_event(
+    async def delete_calendar_event(
         self,
         uid: Optional[str] = None,
         summary: Optional[str] = None,
@@ -1209,20 +1301,23 @@ class Tools:
         if not (summary or uid):
             raise Exception("must provide a summary or uid")
 
-        cal = self.caldav_client.principal().calendar(name=calendar_name)
+        client = await self.caldav_client
+        principal = await client.principal()
+        cal = await self._get_calendar(principal, calendar_name)
         event = None
         if uid:
-            event = cal.event_by_uid(uid)
+            event = await cal.event_by_uid(uid)
         elif summary is not None:
             matches = []
-            for e in cal.events():
+            events = await cal.events()
+            for e in events:
                 c = e.component
                 if summary.strip() in c["summary"]:
                     matches.append(c["uid"])
             if len(matches) > 1:
                 raise Exception(f"multiple matches for summary {summary!r}")
             elif len(matches) == 1:
-                event = cal.event_by_uid(matches[0])
+                event = await cal.event_by_uid(matches[0])
         if not event:
             raise NotFoundError(f"event not found for {summary!r}")
-        event.delete()
+        await event.delete()

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -13,6 +13,7 @@ import functools
 import inspect
 import os
 import re
+import time
 import traceback
 import urllib.parse
 import uuid
@@ -76,9 +77,38 @@ def tool_logger(func: Callable) -> Callable:
     async def wrapper(self, *args, **kwargs):
         log_sep(func.__name__)
         log_valves(self.valves)
-        result = func(self, *args, **kwargs)
-        if inspect.isawaitable(result):
-            return await result
+        if DEBUG:
+            arg_parts = []
+            for k, v in kwargs.items():
+                arg_parts.append(f"{k}={v!r}")
+            if arg_parts:
+                log(f"args: {', '.join(arg_parts)}")
+        start = time.monotonic()
+        try:
+            result = func(self, *args, **kwargs)
+            if inspect.isawaitable(result):
+                result = await result
+            else:
+                result
+        except Exception as e:
+            elapsed = (time.monotonic() - start) * 1000
+            log_err(
+                f"{func.__name__}: FAILED in {elapsed:.1f}ms — {type(e).__name__}: {e}"
+            )
+            raise
+        elapsed = (time.monotonic() - start) * 1000
+        if isinstance(result, dict):
+            ok = result.get("result", "?")
+            data = result.get("data")
+            if data is not None:
+                data_len = (
+                    len(data) if isinstance(data, (list, str)) else type(data).__name__
+                )
+                log(f"{func.__name__}: {ok} in {elapsed:.1f}ms, data={data_len}")
+            else:
+                log(f"{func.__name__}: {ok} in {elapsed:.1f}ms")
+        else:
+            log(f"{func.__name__}: OK in {elapsed:.1f}ms")
         return result
 
     return wrapper

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -72,43 +72,51 @@ def log_valves(valves):
         print(f"TASK_LIST_WHITELIST={valves.TASK_LIST_WHITELIST!r}")
 
 
+def _sanitize_args(kwargs: dict) -> str:
+    parts = []
+    for k, v in kwargs.items():
+        if k == "__user__":
+            continue
+        parts.append(f"{k}={v!r}")
+    return ", ".join(parts)
+
+
 def tool_logger(func: Callable) -> Callable:
     @functools.wraps(func)
     async def wrapper(self, *args, **kwargs):
         log_sep(func.__name__)
-        log_valves(self.valves)
+        if DEBUG and kwargs:
+            log(f"args: {_sanitize_args(kwargs)}")
         if DEBUG:
-            arg_parts = []
-            for k, v in kwargs.items():
-                arg_parts.append(f"{k}={v!r}")
-            if arg_parts:
-                log(f"args: {', '.join(arg_parts)}")
-        start = time.monotonic()
+            start = time.monotonic()
         try:
             result = func(self, *args, **kwargs)
             if inspect.isawaitable(result):
                 result = await result
-            else:
-                result
         except Exception as e:
-            elapsed = (time.monotonic() - start) * 1000
-            log_err(
-                f"{func.__name__}: FAILED in {elapsed:.1f}ms — {type(e).__name__}: {e}"
-            )
-            raise
-        elapsed = (time.monotonic() - start) * 1000
-        if isinstance(result, dict):
-            ok = result.get("result", "?")
-            data = result.get("data")
-            if data is not None:
-                data_len = (
-                    len(data) if isinstance(data, (list, str)) else type(data).__name__
+            if DEBUG:
+                elapsed = (time.monotonic() - start) * 1000
+                log_err(
+                    f"{func.__name__}: FAILED in {elapsed:.1f}ms "
+                    f"— {type(e).__name__}: {e}"
                 )
-                log(f"{func.__name__}: {ok} in {elapsed:.1f}ms, data={data_len}")
+            raise
+        if DEBUG:
+            elapsed = (time.monotonic() - start) * 1000
+            if isinstance(result, dict):
+                ok = result.get("result", "?")
+                data = result.get("data")
+                if data is not None:
+                    data_len = (
+                        len(data)
+                        if isinstance(data, (list, str))
+                        else type(data).__name__
+                    )
+                    log(f"{func.__name__}: {ok} in {elapsed:.1f}ms, data={data_len}")
+                else:
+                    log(f"{func.__name__}: {ok} in {elapsed:.1f}ms")
             else:
-                log(f"{func.__name__}: {ok} in {elapsed:.1f}ms")
-        else:
-            log(f"{func.__name__}: OK in {elapsed:.1f}ms")
+                log(f"{func.__name__}: OK in {elapsed:.1f}ms")
         return result
 
     return wrapper

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -298,8 +298,7 @@ class Tools:
         )
         pass  # required for parsing
 
-    @property
-    def webdav_client(self):
+    def _webdav_client(self):
         base = self.valves.NEXTCLOUD_BASE_URL
         wd_user = self.valves.WEBDAV_USERNAME
         url = f"{base}/remote.php/dav/files/{wd_user}/"
@@ -407,7 +406,7 @@ class Tools:
         path: str,
     ) -> None:
         """Create new directory"""
-        client = self.webdav_client
+        client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             await client.mkdir(_webdav_path(validate_path(path, self.valves)))
@@ -418,7 +417,7 @@ class Tools:
     @webdav_safe
     async def ls(self, path: str | None = None) -> list[str]:
         """List files and directories"""
-        client = self.webdav_client
+        client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             p = validate_path(path, self.valves)
@@ -452,7 +451,7 @@ class Tools:
         Returns:
             matching file paths sorted by modification time (newest last)
         """
-        client = self.webdav_client
+        client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             target_dir = validate_path(path if path else "", self.valves)
@@ -541,7 +540,7 @@ class Tools:
             path: The directory to search in. Defaults to root.
             include: File pattern to include (e.g., "*.py", "*.{ts,tsx}")
         """
-        client = self.webdav_client
+        client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             target_dir = validate_path(path if path else "", self.valves)
@@ -644,7 +643,7 @@ class Tools:
         """Write to a file, overwriting existing content"""
         if content is None:
             content = ""
-        client = self.webdav_client
+        client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             await client.resource(
@@ -677,7 +676,7 @@ class Tools:
         if limit is not None and limit <= 0:
             raise ValueError(f"limit must be > 0, got {limit}")
 
-        client = self.webdav_client
+        client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             buf = BytesIO()
@@ -708,7 +707,7 @@ class Tools:
         """Append content to file, creating it if it does not exist"""
         if content is None:
             content = ""
-        client = self.webdav_client
+        client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             res_path = _webdav_path(validate_path(path, self.valves))
@@ -748,7 +747,7 @@ class Tools:
         if old_string == new_string:
             raise ValueError("old_string and new_string must be different")
 
-        client = self.webdav_client
+        client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             res_path = _webdav_path(validate_path(file_path, self.valves))
@@ -781,7 +780,7 @@ class Tools:
     @webdav_safe
     async def rm(self, paths: list[str]) -> None:
         """Deletes files/directories"""
-        client = self.webdav_client
+        client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             for p in paths:
@@ -797,7 +796,7 @@ class Tools:
         dst: str,
     ) -> None:
         """Move/rename a file or directory"""
-        client = self.webdav_client
+        client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             await client.move(
@@ -815,7 +814,7 @@ class Tools:
         dst: str,
     ) -> None:
         """Copy a file or directory."""
-        client = self.webdav_client
+        client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             await client.copy(

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 # Modern import mode prevents sys.path hacks and name collisions
 addopts = --import-mode=importlib -rA
 
-# Test discovery paths - exclude e2e by default (use pytest tests/e2e/ explicitly for E2E)
+# Test discovery paths
 testpaths = tests/unit tests/integration
 
 # Make project root importable for editable installs
@@ -11,7 +11,3 @@ pythonpath = .
 # Catch undefined markers early
 strict_config = true
 strict_markers = true
-
-# Markers
-markers =
-    e2e: marks tests as end-to-end (requires live OpenWebUI + Nextcloud)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-asyncio
 pre-commit
 types-requests
 sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 icalendar
-caldav
-webdavclient3
+caldav>=3.0.0
+aiowebdav2
 pydantic
 python-dotenv
 requests

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="owuinc",
-    version="2.4.0",
+    version="3.0.0",
     author="soakedcardinal",
     description="openwebui nextcloud integration",
     url="https://github.com/soakedcardinal/owuinc",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="owuinc",
-    version="2.3.0",
+    version="2.4.0",
     author="soakedcardinal",
     description="openwebui nextcloud integration",
     url="https://github.com/soakedcardinal/owuinc",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -442,9 +442,8 @@ async def webdav_tools(wsgidav_server):
         f"sandbox={t.valves.SANDBOX_DIR}"
     )
 
-    original_webdav_client = Tools.webdav_client
+    original_webdav_client = Tools._webdav_client
 
-    @property
     def wsgi_webdav_client(self):
         return WebDAVClient(
             f"{self.valves.NEXTCLOUD_BASE_URL}/remote.php/dav/files/"
@@ -453,11 +452,11 @@ async def webdav_tools(wsgidav_server):
             self.valves.NEXTCLOUD_APP_PASSWORD,
         )
 
-    Tools.webdav_client = wsgi_webdav_client
+    Tools._webdav_client = wsgi_webdav_client
 
     try:
         logger.info(">>> Yielding webdav_tools instance")
         yield t
     finally:
-        Tools.webdav_client = original_webdav_client
-        logger.info(">>> Restored original Tools.webdav_client property")
+        Tools._webdav_client = original_webdav_client
+        logger.info(">>> Restored original Tools._webdav_client method")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,7 @@
-"""Integration test fixtures for CalDAV (Radicale) and WebDAV (WsgiDAV) testing."""
+"""Integration test fixtures for CalDAV (Radicale) and WebDAV (WsgiDAV) testing.
+
+All fixtures and tests are async to match the async tool methods in owuinc.py.
+"""
 
 import logging
 import os
@@ -10,6 +13,7 @@ import time
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
 
 logger = logging.getLogger(__name__)
 
@@ -194,8 +198,8 @@ level = warning
             logger.info(f">>> Port {RADICALE_PORT} confirmed free after teardown")
 
 
-@pytest.fixture(scope="function")
-def caldav_tools(radicale_server):
+@pytest_asyncio.fixture(scope="function")
+async def caldav_tools(radicale_server):
     """Create Tools instance configured for Radicale CalDAV server.
 
     Args:
@@ -204,10 +208,10 @@ def caldav_tools(radicale_server):
     Yields:
         Tools: Configured owuinc.Tools instance
 
-    Note: Overrides caldav_client to use Radicale's path structure with
+    Note: Overrides caldav_client to use async Radicale client with
           basic auth instead of Nextcloud's /remote.php/dav prefix.
     """
-    from caldav.davclient import get_davclient
+    from caldav.aio import get_async_davclient
 
     from owuinc.owuinc import Tools
 
@@ -233,7 +237,7 @@ def caldav_tools(radicale_server):
 
     @property
     def rad_caldav_client(self):
-        return get_davclient(
+        return get_async_davclient(
             url=self.valves.NEXTCLOUD_BASE_URL,
             username=radicale_server["username"],
             password=radicale_server["password"],
@@ -406,8 +410,8 @@ server.start()
         shutil.rmtree(script_dir, ignore_errors=True)
 
 
-@pytest.fixture(scope="function")
-def webdav_tools(wsgidav_server):
+@pytest_asyncio.fixture(scope="function")
+async def webdav_tools(wsgidav_server):
     """Create Tools instance configured for WsgiDAV with Nextcloud URL structure.
 
     URL: http://127.0.0.1:5233/remote.php/dav/files/testuser/
@@ -418,7 +422,7 @@ def webdav_tools(wsgidav_server):
     Yields:
         Tools: Configured owuinc.Tools instance
     """
-    from webdav3.client import Client
+    from aiowebdav2 import Client as WebDAVClient
 
     from owuinc.owuinc import Tools
 
@@ -442,15 +446,11 @@ def webdav_tools(wsgidav_server):
 
     @property
     def wsgi_webdav_client(self):
-        return Client(
-            {
-                "webdav_hostname": (
-                    f"{self.valves.NEXTCLOUD_BASE_URL}/remote.php/dav/files/"
-                    f"{self.valves.WEBDAV_USERNAME}/"
-                ),
-                "webdav_login": self.valves.NEXTCLOUD_USERNAME,
-                "webdav_password": self.valves.NEXTCLOUD_APP_PASSWORD,
-            }
+        return WebDAVClient(
+            f"{self.valves.NEXTCLOUD_BASE_URL}/remote.php/dav/files/"
+            f"{self.valves.WEBDAV_USERNAME}/",
+            self.valves.NEXTCLOUD_USERNAME,
+            self.valves.NEXTCLOUD_APP_PASSWORD,
         )
 
     Tools.webdav_client = wsgi_webdav_client

--- a/tests/integration/test_calendar_methods.py
+++ b/tests/integration/test_calendar_methods.py
@@ -1,12 +1,28 @@
-"""Integration tests for CalDAV methods using local Radicale server"""
+"""Integration tests for CalDAV methods using local Radicale server.
+
+All tests are async to match the async tool methods in owuinc.py.
+Note: caldav.aio only has principal() as async; other methods are sync
+wrappers that delegate to the async client internally.
+"""
 
 import logging
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import pytest
+import pytest_asyncio
 
 logger = logging.getLogger(__name__)
+
+
+async def _get_calendar(principal, calendar_name: str):
+    """Get a calendar by name, working around caldav.aio's broken calendar()."""
+    calendars = await principal.get_calendars()
+    for cal in calendars:
+        display_name = await cal.get_display_name()
+        if display_name == calendar_name:
+            return cal
+    raise Exception(f"No calendar with name {calendar_name!r} found")
 
 
 class TestServerHealth:
@@ -97,19 +113,21 @@ class TestServerHealth:
 class TestCaldavClient:
     """Tests for the caldav_client fixture override and client connectivity."""
 
-    def test_caldav_client_is_correct_type(self, caldav_tools):
-        """Verify the overridden caldav_client returns a DAVClient instance."""
-        client = caldav_tools.caldav_client
-        from caldav.davclient import DAVClient
+    @pytest.mark.asyncio
+    async def test_caldav_client_is_correct_type(self, caldav_tools):
+        """Verify the overridden caldav_client returns an AsyncDAVClient instance."""
+        client = await caldav_tools.caldav_client
+        from caldav.aio import AsyncDAVClient
 
         logger.info(f">>> [TEST] caldav_client type: {type(client).__name__}")
         assert isinstance(
-            client, DAVClient
-        ), f"Expected DAVClient, got {type(client).__name__}"
+            client, AsyncDAVClient
+        ), f"Expected AsyncDAVClient, got {type(client).__name__}"
 
-    def test_caldav_client_url_is_radicale_root(self, caldav_tools):
+    @pytest.mark.asyncio
+    async def test_caldav_client_url_is_radicale_root(self, caldav_tools):
         """Verify the client points at Radicale root, NOT /remote.php/dav."""
-        client = caldav_tools.caldav_client
+        client = await caldav_tools.caldav_client
         url_str = str(client.url)
         logger.info(f">>> [TEST] caldav_client.url: {url_str}")
         assert (
@@ -119,21 +137,23 @@ class TestCaldavClient:
             "remote.php" not in url_str
         ), f"Client URL should not contain remote.php/dav: {url_str}"
 
-    def test_principal_discovery_works(self, caldav_tools):
+    @pytest.mark.asyncio
+    async def test_principal_discovery_works(self, caldav_tools):
         """Verify the caldav library can discover the principal against Radicale."""
-        client = caldav_tools.caldav_client
-        principal = client.principal()
+        client = await caldav_tools.caldav_client
+        principal = await client.principal()
         logger.info(
             f">>> [TEST] Principal: {principal}, type: {type(principal).__name__}"
         )
         assert principal is not None, "Principal discovery failed"
 
-    def test_caldav_client_property_restored_after_test(self, caldav_tools):
+    @pytest.mark.asyncio
+    async def test_caldav_client_property_restored_after_test(self, caldav_tools):
         """Verify the override is active during test.
 
         Restoration happens in the fixture's finally block.
         """
-        client = caldav_tools.caldav_client
+        client = await caldav_tools.caldav_client
         url_str = str(client.url)
         logger.info(f">>> [TEST] During test, client.url: {url_str}")
         assert (
@@ -148,7 +168,8 @@ class TestCaldavClient:
 class TestGetCalendars:
     """Tests for get_calendars() tool method."""
 
-    def test_get_calendars_returns_empty_when_no_calendars(self, caldav_tools):
+    @pytest.mark.asyncio
+    async def test_get_calendars_returns_empty_when_no_calendars(self, caldav_tools):
         """Verify get_calendars returns empty list when no calendars exist.
 
         Fresh Radicale server starts with no calendars, so this tests that case.
@@ -163,13 +184,13 @@ class TestGetCalendars:
         )
 
         # Verify the caldav_client property is wired correctly
-        client = caldav_tools.caldav_client
+        client = await caldav_tools.caldav_client
         logger.info(f">>> [TEST] caldav_client type: {type(client).__name__}")
         logger.info(f">>> [TEST] caldav_client.url: {client.url}")
 
         # Call the method under test
         logger.info(">>> [TEST] Calling caldav_tools.get_calendars() ...")
-        result = caldav_tools.get_calendars()
+        result = await caldav_tools.get_calendars()
         logger.info(f">>> [TEST] Raw result: {result!r}")
 
         # Assert structure
@@ -193,9 +214,10 @@ class TestGetCalendars:
 
         logger.info(">>> [TEST] === get_calendars test PASS ===")
 
-    def test_get_calendars_result_has_correct_structure(self, caldav_tools):
+    @pytest.mark.asyncio
+    async def test_get_calendars_result_has_correct_structure(self, caldav_tools):
         """Verify the caldav_safe wrapper produces the expected dict structure."""
-        result = caldav_tools.get_calendars()
+        result = await caldav_tools.get_calendars()
 
         # Must be a dict
         assert isinstance(result, dict), f"Expected dict, got {type(result).__name__}"
@@ -221,9 +243,12 @@ class TestGetCalendars:
 class TestGetTaskLists:
     """Tests for get_task_lists() tool method."""
 
-    def test_get_task_lists_returns_empty_when_no_tasks_calendar(self, caldav_tools):
+    @pytest.mark.asyncio
+    async def test_get_task_lists_returns_empty_when_no_tasks_calendar(
+        self, caldav_tools
+    ):
         """Verify get_task_lists returns empty list when no Tasks calendar exists."""
-        result = caldav_tools.get_task_lists()
+        result = await caldav_tools.get_task_lists()
         assert result["result"] == "True"
         assert "data" in result
         assert result["data"] == []
@@ -235,47 +260,54 @@ class TestTaskOperations:
     Covers: add_task, get_tasks, edit_task, complete_task, delete_task.
     """
 
-    @pytest.fixture
-    def tasks_calendar(self, caldav_tools):
+    @pytest_asyncio.fixture
+    async def tasks_calendar(self, caldav_tools):
         """Create a Tasks calendar on the Radicale server."""
-        principal = caldav_tools.caldav_client.principal()
-        cal = principal.make_calendar(name="Tasks", cal_id="tasks")
+        client = await caldav_tools.caldav_client
+        principal = await client.principal()
+        cal = await principal.make_calendar(name="Tasks", cal_id="tasks")
         yield cal
         try:
-            cal.delete()
+            await cal.delete()
         except Exception:
             pass
 
-    @pytest.fixture
-    def personal_calendar(self, caldav_tools):
+    @pytest_asyncio.fixture
+    async def personal_calendar(self, caldav_tools):
         """Create a Personal calendar on the Radicale server."""
-        principal = caldav_tools.caldav_client.principal()
-        cal = principal.make_calendar(name="Personal", cal_id="personal")
+        client = await caldav_tools.caldav_client
+        principal = await client.principal()
+        cal = await principal.make_calendar(name="Personal", cal_id="personal")
         yield cal
         try:
-            cal.delete()
+            await cal.delete()
         except Exception:
             pass
 
-    def test_get_task_lists_with_tasks_calendar(self, caldav_tools, tasks_calendar):
+    @pytest.mark.asyncio
+    async def test_get_task_lists_with_tasks_calendar(
+        self, caldav_tools, tasks_calendar
+    ):
         """Verify get_task_lists returns the Tasks calendar when it exists."""
-        result = caldav_tools.get_task_lists()
+        result = await caldav_tools.get_task_lists()
         assert result["result"] == "True"
         assert "data" in result
         assert "Tasks" in result["data"]
 
-    def test_add_task(self, caldav_tools, tasks_calendar):
+    @pytest.mark.asyncio
+    async def test_add_task(self, caldav_tools, tasks_calendar):
         """Verify add_task creates a task and returns its UID."""
-        result = caldav_tools.add_task(summary="Test task", list_name="Tasks")
+        result = await caldav_tools.add_task(summary="Test task", list_name="Tasks")
         assert result["result"] == "True"
         assert "data" in result
         assert result["data"] is not None
         assert len(result["data"]) == 36  # UUID format
 
-    def test_get_tasks(self, caldav_tools, tasks_calendar):
+    @pytest.mark.asyncio
+    async def test_get_tasks(self, caldav_tools, tasks_calendar):
         """Verify get_tasks returns tasks from the Tasks calendar."""
-        caldav_tools.add_task(summary="Get tasks test", list_name="Tasks")
-        result = caldav_tools.get_tasks(list_name="Tasks")
+        await caldav_tools.add_task(summary="Get tasks test", list_name="Tasks")
+        result = await caldav_tools.get_tasks(list_name="Tasks")
         assert result["result"] == "True"
         assert "data" in result
         assert isinstance(result["data"], list)
@@ -283,17 +315,18 @@ class TestTaskOperations:
         summaries = [t.get("summary") for t in result["data"]]
         assert "Get tasks test" in summaries
 
-    def test_edit_task(self, caldav_tools, tasks_calendar):
+    @pytest.mark.asyncio
+    async def test_edit_task(self, caldav_tools, tasks_calendar):
         """Verify edit_task modifies a task's summary."""
-        add_result = caldav_tools.add_task(
+        add_result = await caldav_tools.add_task(
             summary="Original summary", list_name="Tasks"
         )
         uid = add_result["data"]
-        edit_result = caldav_tools.edit_task(
+        edit_result = await caldav_tools.edit_task(
             uid=uid, new_summary="Edited summary", list_name="Tasks"
         )
         assert edit_result["result"] == "True"
-        tasks = caldav_tools.get_tasks(list_name="Tasks")
+        tasks = await caldav_tools.get_tasks(list_name="Tasks")
         for t in tasks["data"]:
             if t.get("uid") == uid:
                 assert t.get("summary") == "Edited summary"
@@ -301,35 +334,39 @@ class TestTaskOperations:
         else:
             assert False, f"Task with uid {uid} not found after edit"
 
-    def test_complete_task(self, caldav_tools, tasks_calendar):
+    @pytest.mark.asyncio
+    async def test_complete_task(self, caldav_tools, tasks_calendar):
         """Verify complete_task marks a task as COMPLETED.
 
         Note: get_tasks filters out completed tasks (expected CalDAV behavior),
         so we can't verify via round-trip through get_tasks. We verify the
         method returns success and the task is no longer in get_tasks results.
         """
-        add_result = caldav_tools.add_task(summary="To complete", list_name="Tasks")
+        add_result = await caldav_tools.add_task(
+            summary="To complete", list_name="Tasks"
+        )
         uid = add_result["data"]
         # Confirm task exists before completing
-        before = caldav_tools.get_tasks(list_name="Tasks")
+        before = await caldav_tools.get_tasks(list_name="Tasks")
         uids_before = [t.get("uid") for t in before["data"]]
         assert uid in uids_before, "Task should exist before completing"
 
-        comp_result = caldav_tools.complete_task(uid=uid, list_name="Tasks")
+        comp_result = await caldav_tools.complete_task(uid=uid, list_name="Tasks")
         assert comp_result["result"] == "True"
 
         # Verify task is gone from get_tasks (completed tasks are filtered out)
-        after = caldav_tools.get_tasks(list_name="Tasks")
+        after = await caldav_tools.get_tasks(list_name="Tasks")
         uids_after = [t.get("uid") for t in after["data"]]
         assert uid not in uids_after, "Completed task should not appear in get_tasks"
 
-    def test_delete_task(self, caldav_tools, tasks_calendar):
+    @pytest.mark.asyncio
+    async def test_delete_task(self, caldav_tools, tasks_calendar):
         """Verify delete_task removes a task from the list."""
-        add_result = caldav_tools.add_task(summary="To delete", list_name="Tasks")
+        add_result = await caldav_tools.add_task(summary="To delete", list_name="Tasks")
         uid = add_result["data"]
-        del_result = caldav_tools.delete_task(uid=uid, list_name="Tasks")
+        del_result = await caldav_tools.delete_task(uid=uid, list_name="Tasks")
         assert del_result["result"] == "True"
-        tasks = caldav_tools.get_tasks(list_name="Tasks")
+        tasks = await caldav_tools.get_tasks(list_name="Tasks")
         uids = [t.get("uid") for t in tasks["data"]]
         assert uid not in uids
 
@@ -337,25 +374,26 @@ class TestTaskOperations:
 class TestEventOperations:
     """Tests for calendar event CRUD: create, get, edit, delete."""
 
-    @pytest.fixture
-    def personal_calendar(self, caldav_tools):
+    @pytest_asyncio.fixture
+    async def personal_calendar(self, caldav_tools):
         """Create a Personal calendar on the Radicale server."""
-        principal = caldav_tools.caldav_client.principal()
-        cal = principal.make_calendar(name="Personal", cal_id="personal")
+        client = await caldav_tools.caldav_client
+        principal = await client.principal()
+        cal = await principal.make_calendar(name="Personal", cal_id="personal")
         yield cal
         try:
-            cal.delete()
+            await cal.delete()
         except Exception:
             pass
 
-    @pytest.fixture
-    def future_event(self, caldav_tools, personal_calendar):
+    @pytest_asyncio.fixture
+    async def future_event(self, caldav_tools, personal_calendar):
         """Create an event in the near future for testing."""
         zi = ZoneInfo("America/New_York")
         now = datetime.now(zi).replace(second=0, microsecond=0)
         start = (now + timedelta(hours=1)).isoformat()
         end = (now + timedelta(hours=2)).isoformat()
-        result = caldav_tools.create_calendar_event(
+        result = await caldav_tools.create_calendar_event(
             summary="Test event",
             calendar_name="Personal",
             start=start,
@@ -365,17 +403,18 @@ class TestEventOperations:
         uid = result["data"]
         yield uid
         try:
-            caldav_tools.delete_calendar_event(uid=uid, calendar_name="Personal")
+            await caldav_tools.delete_calendar_event(uid=uid, calendar_name="Personal")
         except Exception:
             pass
 
-    def test_create_calendar_event(self, caldav_tools, personal_calendar):
+    @pytest.mark.asyncio
+    async def test_create_calendar_event(self, caldav_tools, personal_calendar):
         """Verify create_calendar_event creates an event and returns its UID."""
         zi = ZoneInfo("America/New_York")
         now = datetime.now(zi).replace(second=0, microsecond=0)
         start = (now + timedelta(hours=1)).isoformat()
         end = (now + timedelta(hours=2)).isoformat()
-        result = caldav_tools.create_calendar_event(
+        result = await caldav_tools.create_calendar_event(
             summary="Integration test event",
             calendar_name="Personal",
             start=start,
@@ -387,7 +426,8 @@ class TestEventOperations:
         assert result["data"] is not None
         assert len(result["data"]) == 36  # UUID format
 
-    def test_get_calendar_events(self, caldav_tools, future_event):
+    @pytest.mark.asyncio
+    async def test_get_calendar_events(self, caldav_tools, future_event):
         """SKIP: Radicale returns 0 events for all time-range searches.
 
         get_calendar_events uses cal.search(start=datetime.now()), which
@@ -404,12 +444,13 @@ class TestEventOperations:
             "old_flags: no_search_openended)"
         )
 
-    def test_edit_calendar_event(self, caldav_tools, future_event):
+    @pytest.mark.asyncio
+    async def test_edit_calendar_event(self, caldav_tools, future_event):
         """Verify edit_calendar_event modifies an event's summary."""
         zi = ZoneInfo("America/New_York")
         now = datetime.now(zi).replace(second=0, microsecond=0)
         new_start = (now + timedelta(hours=3)).isoformat()
-        edit_result = caldav_tools.edit_calendar_event(
+        edit_result = await caldav_tools.edit_calendar_event(
             uid=future_event,
             calendar_name="Personal",
             new_summary="Edited event",
@@ -419,21 +460,25 @@ class TestEventOperations:
         assert edit_result["result"] == "True"
         # Verify via raw cal.events() — get_calendar_events can't be used
         # because Radicale ignores time-range filters in search()
-        cal = caldav_tools.caldav_client.principal().calendar(name="Personal")
-        for e in cal.events():
+        client = await caldav_tools.caldav_client
+        principal = await client.principal()
+        cal = await _get_calendar(principal, "Personal")
+        events = await cal.events()
+        for e in events:
             if e.component["uid"] == future_event:
                 assert e.component["summary"] == "Edited event"
                 break
         else:
             assert False, f"Event with uid {future_event} not found after edit"
 
-    def test_delete_calendar_event(self, caldav_tools, personal_calendar):
+    @pytest.mark.asyncio
+    async def test_delete_calendar_event(self, caldav_tools, personal_calendar):
         """Verify delete_calendar_event removes an event."""
         zi = ZoneInfo("America/New_York")
         now = datetime.now(zi).replace(second=0, microsecond=0)
         start = (now + timedelta(hours=1)).isoformat()
         end = (now + timedelta(hours=2)).isoformat()
-        add_result = caldav_tools.create_calendar_event(
+        add_result = await caldav_tools.create_calendar_event(
             summary="To delete",
             calendar_name="Personal",
             start=start,
@@ -441,12 +486,14 @@ class TestEventOperations:
             __user__={"timezone": "America/New_York"},
         )
         uid = add_result["data"]
-        del_result = caldav_tools.delete_calendar_event(
+        del_result = await caldav_tools.delete_calendar_event(
             uid=uid, calendar_name="Personal"
         )
         assert del_result["result"] == "True"
         # Verify via raw cal.events() — get_calendar_events can't be used
         # because Radicale ignores time-range filters in search()
-        cal = caldav_tools.caldav_client.principal().calendar(name="Personal")
-        event_uids = [e.component["uid"] for e in cal.events()]
+        client = await caldav_tools.caldav_client
+        principal = await client.principal()
+        cal = await _get_calendar(principal, "Personal")
+        event_uids = [e.component["uid"] for e in await cal.events()]
         assert uid not in event_uids

--- a/tests/integration/test_webdav_file_ops.py
+++ b/tests/integration/test_webdav_file_ops.py
@@ -1,80 +1,95 @@
-"""Integration tests for WebDAV file operations using WsgiDAV."""
+"""Integration tests for WebDAV file operations using WsgiDAV.
+
+All tests are async to match the async tool methods in owuinc.py.
+"""
+
+import pytest
 
 
 class TestMkdir:
-    def test_mkdir_creates_directory(self, webdav_tools):
-        result = webdav_tools.mkdir("testdir")
+    @pytest.mark.asyncio
+    async def test_mkdir_creates_directory(self, webdav_tools):
+        result = await webdav_tools.mkdir("testdir")
         assert result == {"result": "True"}
 
-        listing = webdav_tools.ls("")
+        listing = await webdav_tools.ls("")
         assert listing["result"] == "True"
         assert any("testdir" in p for p in listing["data"])
 
 
 class TestLs:
-    def test_ls_lists_files_and_directories(self, webdav_tools):
-        webdav_tools.mkdir("ls_testdir")
-        webdav_tools.write_file("ls_testfile.txt", "content")
+    @pytest.mark.asyncio
+    async def test_ls_lists_files_and_directories(self, webdav_tools):
+        await webdav_tools.mkdir("ls_testdir")
+        await webdav_tools.write_file("ls_testfile.txt", "content")
 
-        listing = webdav_tools.ls("")
+        listing = await webdav_tools.ls("")
         assert listing["result"] == "True"
         assert any("ls_testdir" in p for p in listing["data"])
         assert any("ls_testfile.txt" in p for p in listing["data"])
 
 
 class TestWriteFile:
-    def test_write_file_creates_file_with_content(self, webdav_tools):
-        result = webdav_tools.write_file("writefile.txt", "hello world")
+    @pytest.mark.asyncio
+    async def test_write_file_creates_file_with_content(self, webdav_tools):
+        result = await webdav_tools.write_file("writefile.txt", "hello world")
         assert result == {"result": "True"}
 
-        content = webdav_tools.read("writefile.txt")
+        content = await webdav_tools.read("writefile.txt")
         assert content["data"] == "hello world"
 
-    def test_write_file_overwrites_existing(self, webdav_tools):
-        webdav_tools.write_file("overwrite.txt", "original")
-        result = webdav_tools.write_file("overwrite.txt", "replaced")
+    @pytest.mark.asyncio
+    async def test_write_file_overwrites_existing(self, webdav_tools):
+        await webdav_tools.write_file("overwrite.txt", "original")
+        result = await webdav_tools.write_file("overwrite.txt", "replaced")
         assert result == {"result": "True"}
 
-        content = webdav_tools.read("overwrite.txt")
+        content = await webdav_tools.read("overwrite.txt")
         assert content["data"] == "replaced"
 
-    def test_write_file_empty_content(self, webdav_tools):
-        result = webdav_tools.write_file("empty.txt")
+    @pytest.mark.asyncio
+    async def test_write_file_empty_content(self, webdav_tools):
+        result = await webdav_tools.write_file("empty.txt")
         assert result == {"result": "True"}
 
-        content = webdav_tools.read("empty.txt")
+        content = await webdav_tools.read("empty.txt")
         assert content["data"] == ""
 
 
 class TestRead:
-    def test_read_returns_file_content(self, webdav_tools):
-        webdav_tools.write_file("readfile.txt", "line1\nline2\nline3")
-        content = webdav_tools.read("readfile.txt")
+    @pytest.mark.asyncio
+    async def test_read_returns_file_content(self, webdav_tools):
+        await webdav_tools.write_file("readfile.txt", "line1\nline2\nline3")
+        content = await webdav_tools.read("readfile.txt")
         assert content["data"] == "line1\nline2\nline3"
 
-    def test_read_with_offset(self, webdav_tools):
-        webdav_tools.write_file("offsetfile.txt", "line1\nline2\nline3")
-        content = webdav_tools.read("offsetfile.txt", offset=2)
+    @pytest.mark.asyncio
+    async def test_read_with_offset(self, webdav_tools):
+        await webdav_tools.write_file("offsetfile.txt", "line1\nline2\nline3")
+        content = await webdav_tools.read("offsetfile.txt", offset=2)
         assert content["data"] == "line2\nline3"
 
-    def test_read_with_limit(self, webdav_tools):
-        webdav_tools.write_file("limitfile.txt", "line1\nline2\nline3")
-        content = webdav_tools.read("limitfile.txt", limit=2)
+    @pytest.mark.asyncio
+    async def test_read_with_limit(self, webdav_tools):
+        await webdav_tools.write_file("limitfile.txt", "line1\nline2\nline3")
+        content = await webdav_tools.read("limitfile.txt", limit=2)
         assert content["data"] == "line1\nline2"
 
-    def test_read_with_offset_and_limit(self, webdav_tools):
-        webdav_tools.write_file("bothfile.txt", "a\nb\nc\nd")
-        content = webdav_tools.read("bothfile.txt", offset=2, limit=2)
+    @pytest.mark.asyncio
+    async def test_read_with_offset_and_limit(self, webdav_tools):
+        await webdav_tools.write_file("bothfile.txt", "a\nb\nc\nd")
+        content = await webdav_tools.read("bothfile.txt", offset=2, limit=2)
         assert content["data"] == "b\nc"
 
 
 class TestGlob:
-    def test_glob_finds_matching_files(self, webdav_tools):
-        webdav_tools.write_file("glob_a.py", "x")
-        webdav_tools.write_file("glob_b.py", "y")
-        webdav_tools.write_file("glob_c.txt", "z")
+    @pytest.mark.asyncio
+    async def test_glob_finds_matching_files(self, webdav_tools):
+        await webdav_tools.write_file("glob_a.py", "x")
+        await webdav_tools.write_file("glob_b.py", "y")
+        await webdav_tools.write_file("glob_c.txt", "z")
 
-        result = webdav_tools.glob("*.py")
+        result = await webdav_tools.glob("*.py")
         assert result["result"] == "True"
         files = result["data"]
         assert len(files) == 2
@@ -83,11 +98,12 @@ class TestGlob:
 
 
 class TestGrep:
-    def test_grep_finds_pattern_in_files(self, webdav_tools):
-        webdav_tools.write_file("grep_a.py", "def foo():\n    return 42")
-        webdav_tools.write_file("grep_b.py", "def bar():\n    return 0")
+    @pytest.mark.asyncio
+    async def test_grep_finds_pattern_in_files(self, webdav_tools):
+        await webdav_tools.write_file("grep_a.py", "def foo():\n    return 42")
+        await webdav_tools.write_file("grep_b.py", "def bar():\n    return 0")
 
-        result = webdav_tools.grep("def foo", include="*.py")
+        result = await webdav_tools.grep("def foo", include="*.py")
         assert result["result"] == "True"
         matches = result["data"]
         assert len(matches) == 1
@@ -95,92 +111,102 @@ class TestGrep:
         assert matches[0]["line"] == 1
         assert "def foo" in matches[0]["content"]
 
-    def test_grep_no_matches(self, webdav_tools):
-        webdav_tools.write_file("grep_nomatch.py", "no match here")
+    @pytest.mark.asyncio
+    async def test_grep_no_matches(self, webdav_tools):
+        await webdav_tools.write_file("grep_nomatch.py", "no match here")
 
-        result = webdav_tools.grep("xyznotfound", include="*.py")
+        result = await webdav_tools.grep("xyznotfound", include="*.py")
         assert result["result"] == "True"
         assert result["data"] == []
 
 
 class TestAppendFile:
-    def test_append_file_adds_content(self, webdav_tools):
-        webdav_tools.write_file("appendfile.txt", "original\n")
-        result = webdav_tools.append_file("appendfile.txt", "appended\n")
+    @pytest.mark.asyncio
+    async def test_append_file_adds_content(self, webdav_tools):
+        await webdav_tools.write_file("appendfile.txt", "original\n")
+        result = await webdav_tools.append_file("appendfile.txt", "appended\n")
         assert result == {"result": "True"}
 
-        content = webdav_tools.read("appendfile.txt")
+        content = await webdav_tools.read("appendfile.txt")
         assert content["data"] == "original\nappended"
 
-    def test_append_file_creates_new_file(self, webdav_tools):
-        result = webdav_tools.append_file("newfile.txt", "first line\n")
+    @pytest.mark.asyncio
+    async def test_append_file_creates_new_file(self, webdav_tools):
+        result = await webdav_tools.append_file("newfile.txt", "first line\n")
         assert result == {"result": "True"}
 
-        content = webdav_tools.read("newfile.txt")
+        content = await webdav_tools.read("newfile.txt")
         assert content["data"] == "first line"
 
 
 class TestEdit:
-    def test_edit_replaces_string(self, webdav_tools):
-        webdav_tools.write_file("editfile.txt", "foo bar baz")
-        result = webdav_tools.edit("editfile.txt", "foo", "qux")
+    @pytest.mark.asyncio
+    async def test_edit_replaces_string(self, webdav_tools):
+        await webdav_tools.write_file("editfile.txt", "foo bar baz")
+        result = await webdav_tools.edit("editfile.txt", "foo", "qux")
         assert result["result"] == "True"
 
-        content = webdav_tools.read("editfile.txt")
+        content = await webdav_tools.read("editfile.txt")
         assert content["data"] == "qux bar baz"
 
-    def test_edit_replace_all(self, webdav_tools):
-        webdav_tools.write_file("editall.txt", "a b a b a")
-        result = webdav_tools.edit("editall.txt", "a", "z", replace_all=True)
+    @pytest.mark.asyncio
+    async def test_edit_replace_all(self, webdav_tools):
+        await webdav_tools.write_file("editall.txt", "a b a b a")
+        result = await webdav_tools.edit("editall.txt", "a", "z", replace_all=True)
         assert result["result"] == "True"
 
-        content = webdav_tools.read("editall.txt")
+        content = await webdav_tools.read("editall.txt")
         assert content["data"] == "z b z b z"
 
-    def test_edit_string_not_found(self, webdav_tools):
-        webdav_tools.write_file("editfail.txt", "hello")
-        result = webdav_tools.edit("editfail.txt", "notfound", "x")
+    @pytest.mark.asyncio
+    async def test_edit_string_not_found(self, webdav_tools):
+        await webdav_tools.write_file("editfail.txt", "hello")
+        result = await webdav_tools.edit("editfail.txt", "notfound", "x")
         assert result["result"] == "False"
 
 
 class TestRm:
-    def test_rm_deletes_file(self, webdav_tools):
-        webdav_tools.write_file("rmfile.txt", "delete me")
-        result = webdav_tools.rm(["rmfile.txt"])
+    @pytest.mark.asyncio
+    async def test_rm_deletes_file(self, webdav_tools):
+        await webdav_tools.write_file("rmfile.txt", "delete me")
+        result = await webdav_tools.rm(["rmfile.txt"])
         assert result == {"result": "True"}
 
-        result = webdav_tools.read("rmfile.txt")
+        result = await webdav_tools.read("rmfile.txt")
         assert result["result"] == "False"
 
-    def test_rm_deletes_directory(self, webdav_tools):
-        webdav_tools.mkdir("rmdir")
-        result = webdav_tools.rm(["rmdir"])
+    @pytest.mark.asyncio
+    async def test_rm_deletes_directory(self, webdav_tools):
+        await webdav_tools.mkdir("rmdir")
+        result = await webdav_tools.rm(["rmdir"])
         assert result == {"result": "True"}
 
-        listing = webdav_tools.ls("")
+        listing = await webdav_tools.ls("")
         assert listing["result"] == "True"
         assert not any("rmdir" in p for p in listing["data"])
 
 
 class TestMv:
-    def test_mv_renames_file(self, webdav_tools):
-        webdav_tools.write_file("mvsrc.txt", "move me")
-        result = webdav_tools.mv("mvsrc.txt", "mvdst.txt")
+    @pytest.mark.asyncio
+    async def test_mv_renames_file(self, webdav_tools):
+        await webdav_tools.write_file("mvsrc.txt", "move me")
+        result = await webdav_tools.mv("mvsrc.txt", "mvdst.txt")
         assert result == {"result": "True"}
 
-        content = webdav_tools.read("mvdst.txt")
+        content = await webdav_tools.read("mvdst.txt")
         assert content["data"] == "move me"
 
-        result = webdav_tools.read("mvsrc.txt")
+        result = await webdav_tools.read("mvsrc.txt")
         assert result["result"] == "False"
 
 
 class TestCp:
-    def test_cp_copies_file(self, webdav_tools):
-        webdav_tools.write_file("cpsrc.txt", "copy me")
-        result = webdav_tools.cp("cpsrc.txt", "cpdst.txt")
+    @pytest.mark.asyncio
+    async def test_cp_copies_file(self, webdav_tools):
+        await webdav_tools.write_file("cpsrc.txt", "copy me")
+        result = await webdav_tools.cp("cpsrc.txt", "cpdst.txt")
         assert result == {"result": "True"}
 
-        src = webdav_tools.read("cpsrc.txt")
-        dst = webdav_tools.read("cpdst.txt")
+        src = await webdav_tools.read("cpsrc.txt")
+        dst = await webdav_tools.read("cpdst.txt")
         assert src["data"] == dst["data"] == "copy me"


### PR DESCRIPTION
Migrate all 22 tool methods to native async using caldav.aio and aiowebdav2.

- All tool methods converted to `async def`
- Replaced webdavclient3 with aiowebdav2
- Replaced sync caldav with caldav.aio (caldav>=3.0.0)
- Decorators updated for async with `inspect.isawaitable()`
- Client lifecycle: try/finally `await client.close()` on all methods
- Fixed unclosed session leaks (both caldav and webdav)
- Enhanced tool_logger with args, timing, and result summary (DEBUG gated)
- Added `_sanitize_args()` to skip `__user__` from debug logs
- Version bumped to 3.0.0