### PR TITLE
fix: prevent sandbox directory path leakage to agents

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "owuinc"
 copyright = "2026, soakedcardinal"
 author = "soakedcardinal"
-release = "3.0.0"
+release = "3.0.1"
 extensions = ["sphinx.ext.autodoc"]
 exclude_patterns: list[str] = []
 html_theme = "sphinx_rtd_theme"

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -180,7 +180,7 @@ def webdav_safe(func: Callable) -> Callable:
             return {"result": "False", "details": f"{op}: connection failed"}
         except WebDavError as e:
             log_err(f"{op}: WebDAV error - {e}\nTraceback: {traceback.format_exc()}")
-            return {"result": "False", "details": f"{op}: {str(e)}"}
+            return {"result": "False", "details": f"{op}: WebDAV error"}
         except ValueError as e:
             log_err(f"{op}: validation error - {e}")
             return {"result": "False", "details": f"{op}: {str(e)}"}

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -182,7 +182,7 @@ def webdav_safe(func: Callable) -> Callable:
             return {"result": "False", "details": f"{op}: WebDAV error"}
         except ValueError as e:
             log_err(f"{op}: validation error - {e}")
-            return {"result": "False", "details": f"{op}: validation error"}
+            return {"result": "False", "details": f"{op}: {str(e)}"}
         except Exception as e:
             log_err(
                 f"{op}: unexpected error - {type(e).__name__}: {e}\

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -135,9 +135,8 @@ def caldav_safe(func: Callable) -> Callable:
                 response["data"] = result
             return response
         except NotFoundError as e:
-            log(f"{op}: {e}")
-            msg = e.args[0] if hasattr(e, "args") and e.args else str(e)
-            return {"result": "False", "details": msg}
+            log_err(f"{op}: not found - {e}")
+            return {"result": "False", "details": f"{op}: not found"}
         except Exception as e:
             log_err(
                 f"{op}: unexpected error - {type(e).__name__}: {e}\
@@ -183,7 +182,7 @@ def webdav_safe(func: Callable) -> Callable:
             return {"result": "False", "details": f"{op}: WebDAV error"}
         except ValueError as e:
             log_err(f"{op}: validation error - {e}")
-            return {"result": "False", "details": f"{op}: {str(e)}"}
+            return {"result": "False", "details": f"{op}: validation error"}
         except Exception as e:
             log_err(
                 f"{op}: unexpected error - {type(e).__name__}: {e}\

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -4,7 +4,7 @@ author: soakedcardinal
 git_url: https://github.com/soakedcardinal/owuinc
 description: Manage files, tasks, and calendars via WebDAV and CalDAV.
 requirements: caldav>=3.0.0,icalendar,aiowebdav2
-version: 3.0.0
+version: 3.0.1
 license: MIT
 """
 
@@ -459,13 +459,18 @@ class Tools:
         try:
             await self._ensure_sandbox(client)
             p = validate_path(path, self.valves)
-            prefix = f"{self.valves.SANDBOX_DIR.strip().rstrip('/')}/"
+            sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
             raw_paths = await client.list_files(_webdav_path(p))
             paths = [_strip_leading_slash(rp) for rp in raw_paths]
-            parent = p.strip(prefix).strip("/")
-            result_list = [
-                item for item in paths if item != prefix and item.strip("/") != parent
-            ]
+            parent = _strip_leading_slash(p)
+            result_list = []
+            for item in paths:
+                if item == parent:
+                    continue
+                # Strip sandbox prefix to keep it invisible to the agent
+                if item.startswith(sandbox_prefix):
+                    item = item[len(sandbox_prefix) :]
+                result_list.append(item)
             return result_list
         finally:
             await client.close()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="owuinc",
-    version="3.0.0",
+    version="3.0.1",
     author="soakedcardinal",
     description="openwebui nextcloud integration",
     url="https://github.com/soakedcardinal/owuinc",


### PR DESCRIPTION
## Summary
- Strip sandbox prefix from `ls` output to match existing `glob`/`grep` behavior
- Sanitize all error messages (`WebDavError`, `NotFoundError`, `ValueError`) to return generic messages instead of raw library errors that may contain paths, usernames, or other sensitive data
- Detailed error info is still logged when `DEBUG=True` for troubleshooting

## Changes
- `ls()` now returns relative paths (e.g., `file.md` instead of `sandbox/file.md`)
- All error handlers in `webdav_safe` and `caldav_safe` return generic messages to the agent
- Bump version to 3.0.1