### PR TITLE
Add FILE_BLACKLIST valve, fix cp/mv

### DIFF
--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -70,6 +70,7 @@ def log_valves(valves):
         print(f"DEFAULT_TASK_LIST={valves.DEFAULT_TASK_LIST!r}")
         print(f"CALENDAR_WHITELIST={valves.CALENDAR_WHITELIST!r}")
         print(f"TASK_LIST_WHITELIST={valves.TASK_LIST_WHITELIST!r}")
+        print(f"FILE_BLACKLIST={valves.FILE_BLACKLIST!r}")
 
 
 def _sanitize_args(kwargs: dict) -> str:
@@ -302,6 +303,17 @@ def is_whitelisted(whitelist: str, item: str) -> bool:
     return item in cleaned_whitelist
 
 
+def is_blacklisted(blacklist: str, path: str) -> bool:
+    """Check if path is under any blacklisted directory prefix."""
+    if not blacklist:
+        return False
+    cleaned = {s.strip() for s in blacklist.split(",") if s.strip()}
+    for prefix in cleaned:
+        if path == prefix or path.startswith(prefix + "/"):
+            return True
+    return False
+
+
 class Tools:
     def __init__(self):
         log_sep("Tools")
@@ -332,6 +344,13 @@ class Tools:
         TASK_LIST_WHITELIST: str = Field(
             default="Tasks",
             description="Comma-separated list of allowed task lists",
+        )
+        FILE_BLACKLIST: str = Field(
+            default="",
+            description=(
+                "Comma-separated paths (relative to sandbox root) to exclude "
+                "from all file operations"
+            ),
         )
         pass  # required for parsing
 
@@ -398,6 +417,17 @@ class Tools:
                 log(f"sandbox dir not found, creating: {sandbox!r}")
                 await client.mkdir(_webdav_path(sandbox))
 
+    def _check_blacklisted(self, rel_path: str) -> None:
+        """Raise ValueError if rel_path (relative to sandbox) is blacklisted."""
+        rel_path = rel_path.strip("/")
+        if rel_path and is_blacklisted(self.valves.FILE_BLACKLIST, rel_path):
+            raise ValueError(f"Path is blacklisted: {rel_path}")
+
+    def _is_result_blacklisted(self, rel_path: str) -> bool:
+        """Check if a result path (relative to sandbox) should be hidden."""
+        rel_path = rel_path.strip("/")
+        return bool(rel_path) and is_blacklisted(self.valves.FILE_BLACKLIST, rel_path)
+
     @tool_logger
     @caldav_safe
     async def get_calendars(self) -> list[str]:
@@ -443,10 +473,18 @@ class Tools:
         path: str,
     ) -> None:
         """Create new directory"""
+        full_path = validate_path(path, self.valves)
+        sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
+        rel_path = (
+            full_path[len(sandbox_prefix) :]
+            if full_path.startswith(sandbox_prefix)
+            else full_path
+        )
+        self._check_blacklisted(rel_path)
         client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
-            await client.mkdir(_webdav_path(validate_path(path, self.valves)))
+            await client.mkdir(_webdav_path(full_path))
         finally:
             await client.close()
 
@@ -454,22 +492,28 @@ class Tools:
     @webdav_safe
     async def ls(self, path: str | None = None) -> list[str]:
         """List files and directories"""
+        full_path = validate_path(path, self.valves)
+        sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
+        rel_path = (
+            full_path[len(sandbox_prefix) :]
+            if full_path.startswith(sandbox_prefix)
+            else full_path
+        )
+        self._check_blacklisted(rel_path)
         client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
-            p = validate_path(path, self.valves)
-            sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
-            raw_paths = await client.list_files(_webdav_path(p))
+            raw_paths = await client.list_files(_webdav_path(full_path))
             paths = [_strip_leading_slash(rp) for rp in raw_paths]
-            parent = _strip_leading_slash(p)
+            parent = _strip_leading_slash(full_path)
             result_list = []
             for item in paths:
                 if item == parent:
                     continue
-                # Strip sandbox prefix to keep it invisible to the agent
                 if item.startswith(sandbox_prefix):
                     item = item[len(sandbox_prefix) :]
-                result_list.append(item)
+                if not self._is_result_blacklisted(item):
+                    result_list.append(item)
             return result_list
         finally:
             await client.close()
@@ -493,10 +537,18 @@ class Tools:
         Returns:
             matching file paths sorted by modification time (newest last)
         """
+        target_dir = validate_path(path if path else "", self.valves)
+        sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
+        rel_path = (
+            target_dir[len(sandbox_prefix) :]
+            if target_dir.startswith(sandbox_prefix)
+            else target_dir
+        )
+        self._check_blacklisted(rel_path)
+
         client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
-            target_dir = validate_path(path if path else "", self.valves)
 
             log(f"glob: pattern={pattern}, target_dir={target_dir}")
 
@@ -552,15 +604,20 @@ class Tools:
             except Exception as e:
                 log(f"glob: sort error - {e}")
 
-            sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
             result = []
             for f in matched:
                 full_path = f["path"]
                 if sandbox_prefix in full_path:
-                    rel_path = full_path.split(sandbox_prefix, 1)[1]
+                    rel = full_path.split(sandbox_prefix, 1)[1]
+                elif full_path.startswith(rel_path + "/"):
+                    rel = full_path[len(rel_path) + 1 :]
                 else:
-                    rel_path = os.path.basename(full_path)
-                result.append(rel_path)
+                    rel = os.path.basename(full_path)
+
+                if self._is_result_blacklisted(rel):
+                    continue
+
+                result.append(rel)
 
             log(f"glob: returning {len(result)} matches")
             return result
@@ -582,10 +639,18 @@ class Tools:
             path: The directory to search in. Defaults to root.
             include: File pattern to include (e.g., "*.py", "*.{ts,tsx}")
         """
+        target_dir = validate_path(path if path else "", self.valves)
+        sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
+        search_rel = (
+            target_dir[len(sandbox_prefix) :]
+            if target_dir.startswith(sandbox_prefix)
+            else target_dir
+        )
+        self._check_blacklisted(search_rel)
+
         client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
-            target_dir = validate_path(path if path else "", self.valves)
 
             log(
                 f"grep: pattern={pattern!r}, "
@@ -624,13 +689,17 @@ class Tools:
 
             results = []
             for full_path in file_list:
-                sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
-                rel_path = (
-                    full_path.split(sandbox_prefix, 1)[1]
-                    if sandbox_prefix in full_path
-                    else os.path.basename(full_path)
-                )
-                filename = os.path.basename(rel_path)
+                if sandbox_prefix in full_path:
+                    rel = full_path.split(sandbox_prefix, 1)[1]
+                elif full_path.startswith(search_rel + "/"):
+                    rel = full_path[len(search_rel) + 1 :]
+                else:
+                    rel = os.path.basename(full_path)
+
+                if self._is_result_blacklisted(rel):
+                    continue
+
+                filename = os.path.basename(rel)
 
                 if patterns_to_match:
                     matched = False
@@ -642,8 +711,8 @@ class Tools:
                     if not matched:
                         continue
 
-                webdav_path = _webdav_path(validate_path(rel_path, self.valves))
-                log(f"grep: searching {rel_path}")
+                webdav_path = _webdav_path(validate_path(rel, self.valves))
+                log(f"grep: searching {rel}")
 
                 try:
                     buf = BytesIO()
@@ -659,14 +728,14 @@ class Tools:
                         if compiled_regex.search(line):
                             results.append(
                                 {
-                                    "file": rel_path,
+                                    "file": rel,
                                     "line": line_num,
                                     "content": line.strip(),
                                 }
                             )
 
                 except Exception as e:
-                    log(f"grep: error reading {rel_path}: {e}")
+                    log(f"grep: error reading {rel}: {e}")
                     continue
 
             results.sort(key=lambda x: (x["file"], x["line"]))
@@ -685,12 +754,20 @@ class Tools:
         """Write to a file, overwriting existing content"""
         if content is None:
             content = ""
+        full_path = validate_path(path, self.valves)
+        sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
+        rel_path = (
+            full_path[len(sandbox_prefix) :]
+            if full_path.startswith(sandbox_prefix)
+            else full_path
+        )
+        self._check_blacklisted(rel_path)
         client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
-            await client.resource(
-                _webdav_path(validate_path(path, self.valves))
-            ).write_to(BytesIO(content.encode("utf-8")))
+            await client.resource(_webdav_path(full_path)).write_to(
+                BytesIO(content.encode("utf-8"))
+            )
         finally:
             await client.close()
 
@@ -718,13 +795,20 @@ class Tools:
         if limit is not None and limit <= 0:
             raise ValueError(f"limit must be > 0, got {limit}")
 
+        full_path = validate_path(path, self.valves)
+        sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
+        rel_path = (
+            full_path[len(sandbox_prefix) :]
+            if full_path.startswith(sandbox_prefix)
+            else full_path
+        )
+        self._check_blacklisted(rel_path)
+
         client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             buf = BytesIO()
-            await client.resource(
-                _webdav_path(validate_path(path, self.valves))
-            ).read_from(buf)
+            await client.resource(_webdav_path(full_path)).read_from(buf)
             content = buf.getvalue().decode("utf-8")
             lines = content.splitlines()
 
@@ -749,10 +833,19 @@ class Tools:
         """Append content to file, creating it if it does not exist"""
         if content is None:
             content = ""
+        full_path = validate_path(path, self.valves)
+        sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
+        rel_path = (
+            full_path[len(sandbox_prefix) :]
+            if full_path.startswith(sandbox_prefix)
+            else full_path
+        )
+        self._check_blacklisted(rel_path)
+
         client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
-            res_path = _webdav_path(validate_path(path, self.valves))
+            res_path = _webdav_path(full_path)
             res = client.resource(res_path)
             try:
                 buf = BytesIO()
@@ -789,10 +882,19 @@ class Tools:
         if old_string == new_string:
             raise ValueError("old_string and new_string must be different")
 
+        full_path = validate_path(file_path, self.valves)
+        sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
+        rel_path = (
+            full_path[len(sandbox_prefix) :]
+            if full_path.startswith(sandbox_prefix)
+            else full_path
+        )
+        self._check_blacklisted(rel_path)
+
         client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
-            res_path = _webdav_path(validate_path(file_path, self.valves))
+            res_path = _webdav_path(full_path)
             buf = BytesIO()
             await client.resource(res_path).read_from(buf)
             content = buf.getvalue().decode("utf-8")
@@ -822,6 +924,16 @@ class Tools:
     @webdav_safe
     async def rm(self, paths: list[str]) -> None:
         """Deletes files/directories"""
+        sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
+        for p in paths:
+            full_path = validate_path(p, self.valves)
+            rel_path = (
+                full_path[len(sandbox_prefix) :]
+                if full_path.startswith(sandbox_prefix)
+                else full_path
+            )
+            self._check_blacklisted(rel_path)
+
         client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
@@ -838,12 +950,29 @@ class Tools:
         dst: str,
     ) -> None:
         """Move/rename a file or directory"""
+        sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
+        src_full = validate_path(src, self.valves)
+        src_rel = (
+            src_full[len(sandbox_prefix) :]
+            if src_full.startswith(sandbox_prefix)
+            else src_full
+        )
+        self._check_blacklisted(src_rel)
+
+        dst_full = validate_path(dst, self.valves)
+        dst_rel = (
+            dst_full[len(sandbox_prefix) :]
+            if dst_full.startswith(sandbox_prefix)
+            else dst_full
+        )
+        self._check_blacklisted(dst_rel)
+
         client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             await client.move(
-                remote_path_from=_webdav_path(validate_path(src, self.valves)),
-                remote_path_to=_webdav_path(validate_path(dst, self.valves)),
+                remote_path_from=_webdav_path(src_full),
+                remote_path_to=_webdav_path(dst_full),
             )
         finally:
             await client.close()
@@ -856,12 +985,29 @@ class Tools:
         dst: str,
     ) -> None:
         """Copy a file or directory."""
+        sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
+        src_full = validate_path(src, self.valves)
+        src_rel = (
+            src_full[len(sandbox_prefix) :]
+            if src_full.startswith(sandbox_prefix)
+            else src_full
+        )
+        self._check_blacklisted(src_rel)
+
+        dst_full = validate_path(dst, self.valves)
+        dst_rel = (
+            dst_full[len(sandbox_prefix) :]
+            if dst_full.startswith(sandbox_prefix)
+            else dst_full
+        )
+        self._check_blacklisted(dst_rel)
+
         client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
             await client.copy(
-                remote_path_from=_webdav_path(validate_path(src, self.valves)),
-                remote_path_to=_webdav_path(validate_path(dst, self.valves)),
+                remote_path_from=_webdav_path(src_full),
+                remote_path_to=_webdav_path(dst_full),
             )
         finally:
             await client.close()

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -648,17 +648,57 @@ class Tools:
                     alternatives = pattern[start + 1 : end].split(",")
                     patterns_to_match = [prefix + alt + suffix for alt in alternatives]
 
+            target_root = target_dir.rstrip("/")
             matched = []
             for file_info in files_only:
                 full_path = _strip_leading_slash(file_info.get("path", ""))
                 filename = os.path.basename(full_path)
 
-                log(f"glob: checking {filename} against patterns")
+                # Skip files outside target directory
+                if not (
+                    full_path == target_root or full_path.startswith(target_root + "/")
+                ):
+                    continue
+
+                # Compute path relative to target directory
+                if full_path.startswith(target_root + "/"):
+                    rel_to_target = full_path[len(target_root) + 1 :]
+                else:
+                    rel_to_target = filename
+
+                log(f"glob: checking {rel_to_target} against patterns")
 
                 for pat in patterns_to_match:
-                    pattern_name = pat.split("/")[-1] if "/" in pat else pat
+                    # Split pattern into directory prefix and name pattern
+                    if "/**/" in pat:
+                        dir_prefix, pattern_name = pat.split("/**/", 1)
+                    elif "/" in pat:
+                        # Pattern like "subdir/*.py" — match only in that directory
+                        parts = pat.rsplit("/", 1)
+                        dir_prefix = parts[0]
+                        pattern_name = parts[1]
+                    else:
+                        dir_prefix = ""
+                        pattern_name = pat
+
+                    # Enforce directory scope from pattern
+                    if dir_prefix:
+                        if "/**" in dir_prefix:
+                            # dir_prefix itself may contain ** (edge case)
+                            base = dir_prefix.split("/**")[0]
+                            if not rel_to_target.startswith(base + "/"):
+                                continue
+                        else:
+                            # Exact directory match only
+                            if not rel_to_target.startswith(dir_prefix + "/"):
+                                continue
+                            # No subdirs for non-** patterns
+                            remaining = rel_to_target[len(dir_prefix) + 1 :]
+                            if "/" in remaining:
+                                continue
+
                     if fnmatch.fnmatch(filename, pattern_name):
-                        log(f"glob: matched {filename}")
+                        log(f"glob: matched {rel_to_target}")
                         matched.append(
                             {
                                 "path": full_path,

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -1050,6 +1050,26 @@ class Tools:
         finally:
             await client.close()
 
+    async def _recursive_cp(self, client, src_full: str, dst_full: str) -> None:
+        """Recursively copy a file or directory."""
+        src_path = _webdav_path(src_full)
+        dst_path = _webdav_path(dst_full)
+        if await client.is_dir(src_path):
+            await client.mkdir(dst_path, exist_ok=True)
+            items = await client.list_files(src_path)
+            for item in items:
+                item_stripped = _strip_leading_slash(item)
+                if item_stripped == _strip_leading_slash(src_full):
+                    continue
+                src_item = src_full.rstrip("/") + "/" + item_stripped.lstrip("/")
+                dst_item = dst_full.rstrip("/") + "/" + item_stripped.lstrip("/")
+                await self._recursive_cp(client, src_item, dst_item)
+        else:
+            await client.copy(
+                remote_path_from=src_path,
+                remote_path_to=dst_path,
+            )
+
     @tool_logger
     @webdav_safe
     async def mv(
@@ -1081,6 +1101,7 @@ class Tools:
             await client.move(
                 remote_path_from=_webdav_path(src_full),
                 remote_path_to=_webdav_path(dst_full),
+                overwrite=True,
             )
         finally:
             await client.close()
@@ -1113,10 +1134,7 @@ class Tools:
         client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
-            await client.copy(
-                remote_path_from=_webdav_path(src_full),
-                remote_path_to=_webdav_path(dst_full),
-            )
+            await self._recursive_cp(client, src_full, dst_full)
         finally:
             await client.close()
 
@@ -1140,7 +1158,6 @@ class Tools:
                 task_map[todo.component["uid"]] = {
                     key: todo.component.get(key)
                     for key in [
-                        "uid",
                         "summary",
                         "description",
                         "location",

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -4,7 +4,7 @@ author: soakedcardinal
 git_url: https://github.com/soakedcardinal/owuinc
 description: Manage files, tasks, and calendars via WebDAV and CalDAV.
 requirements: caldav>=3.0.0,icalendar,aiowebdav2
-version: 3.1.0
+version: 3.2.0
 license: MIT
 """
 
@@ -488,10 +488,53 @@ class Tools:
         finally:
             await client.close()
 
+    def _format_size(self, size_str: str) -> str:
+        """Format file size to human-readable string."""
+        try:
+            size: float = int(size_str)
+        except (ValueError, TypeError):
+            return size_str
+        for unit in ("B", "KB", "MB", "GB", "TB"):
+            if abs(size) < 1024:
+                if unit == "B":
+                    return f"{int(size)} {unit}"
+                return f"{size:.1f} {unit}"
+            size /= 1024
+        return f"{size:.1f} PB"
+
+    def _format_datetime(self, dt_str: str) -> str:
+        """Format WebDAV datetime string to a readable format."""
+        if not dt_str:
+            return "n/a"
+        for fmt in (
+            "%a, %d %b %Y %H:%M:%S %Z",
+            "%Y-%m-%dT%H:%M:%SZ",
+            "%Y-%m-%dT%H:%M:%S%z",
+            "%Y-%m-%dT%H:%M:%S",
+        ):
+            try:
+                parsed = datetime.strptime(dt_str.replace(" +0000", "+00:00"), fmt)
+                return parsed.strftime("%Y-%m-%d %H:%M:%S")
+            except ValueError:
+                continue
+        try:
+            parsed = datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
+            return parsed.strftime("%Y-%m-%d %H:%M:%S")
+        except Exception:
+            return dt_str
+
     @tool_logger
     @webdav_safe
-    async def ls(self, path: str | None = None) -> list[str]:
-        """List files and directories"""
+    async def ls(self, path: str | None = None, detail: bool = False) -> list[str]:
+        """List files and directories.
+
+        Args:
+            path: The directory to list. Defaults to sandbox root.
+            detail: If True, include file details (size, modified, type).
+
+        Returns:
+            List of file names, or list of detailed strings when detail=True.
+        """
         full_path = validate_path(path, self.valves)
         sandbox_prefix = self.valves.SANDBOX_DIR.strip().rstrip("/") + "/"
         rel_path = (
@@ -503,6 +546,31 @@ class Tools:
         client = self._webdav_client()
         try:
             await self._ensure_sandbox(client)
+
+            if detail:
+                raw_items = await client.list_with_infos(_webdav_path(full_path))
+                result_list = []
+                for item in raw_items:
+                    full_item_path = _strip_leading_slash(item.get("path", ""))
+                    if full_item_path == _strip_leading_slash(full_path):
+                        continue
+                    rel_item = (
+                        full_item_path[len(sandbox_prefix) :]
+                        if full_item_path.startswith(sandbox_prefix)
+                        else os.path.basename(full_item_path)
+                    )
+                    if self._is_result_blacklisted(rel_item):
+                        continue
+                    is_dir = str(item.get("isdir", "False")).lower() == "true"
+                    type_str = "DIR" if is_dir else "FILE"
+                    size_str = self._format_size(item.get("size", "0"))
+                    modified = self._format_datetime(item.get("modified", ""))
+                    name = item.get("name", os.path.basename(full_item_path))
+                    result_list.append(
+                        f"[{type_str}] {size_str:>10}  {modified}  {name}"
+                    )
+                return result_list
+
             raw_paths = await client.list_files(_webdav_path(full_path))
             paths = [_strip_leading_slash(rp) for rp in raw_paths]
             parent = _strip_leading_slash(full_path)

--- a/owuinc/owuinc.py
+++ b/owuinc/owuinc.py
@@ -651,14 +651,20 @@ class Tools:
             target_root = target_dir.rstrip("/")
             matched = []
             for file_info in files_only:
-                full_path = _strip_leading_slash(file_info.get("path", ""))
+                raw_path = _strip_leading_slash(file_info.get("path", ""))
+                # aiowebdav2.list_with_infos may return full WebDAV paths
+                # (e.g., "remote.php/dav/files/testuser/owuinc/foo.txt") or
+                # sandbox-relative paths (e.g., "owuinc/foo.txt").
+                # Normalize: if target_root is already in the path, use as-is;
+                # otherwise prepend target_root.
+                if raw_path.startswith(target_root + "/") or raw_path == target_root:
+                    full_path = raw_path
+                elif target_root + "/" in raw_path:
+                    # Full WebDAV path — use as-is (sandbox_prefix will strip later)
+                    full_path = raw_path
+                else:
+                    full_path = target_root + "/" + raw_path
                 filename = os.path.basename(full_path)
-
-                # Skip files outside target directory
-                if not (
-                    full_path == target_root or full_path.startswith(target_root + "/")
-                ):
-                    continue
 
                 # Compute path relative to target directory
                 if full_path.startswith(target_root + "/"):
@@ -717,8 +723,11 @@ class Tools:
                 full_path = f["path"]
                 if sandbox_prefix in full_path:
                     rel = full_path.split(sandbox_prefix, 1)[1]
-                elif full_path.startswith(rel_path + "/"):
+                elif rel_path and full_path.startswith(rel_path + "/"):
                     rel = full_path[len(rel_path) + 1 :]
+                elif not rel_path:
+                    # At sandbox root — full_path is already relative to sandbox
+                    rel = full_path
                 else:
                     rel = os.path.basename(full_path)
 

--- a/tests/integration/test_calendar_methods.py
+++ b/tests/integration/test_calendar_methods.py
@@ -327,12 +327,8 @@ class TestTaskOperations:
         )
         assert edit_result["result"] == "True"
         tasks = await caldav_tools.get_tasks(list_name="Tasks")
-        for t in tasks["data"]:
-            if t.get("uid") == uid:
-                assert t.get("summary") == "Edited summary"
-                break
-        else:
-            assert False, f"Task with uid {uid} not found after edit"
+        summaries = [t.get("summary") for t in tasks["data"]]
+        assert "Edited summary" in summaries
 
     @pytest.mark.asyncio
     async def test_complete_task(self, caldav_tools, tasks_calendar):
@@ -348,8 +344,8 @@ class TestTaskOperations:
         uid = add_result["data"]
         # Confirm task exists before completing
         before = await caldav_tools.get_tasks(list_name="Tasks")
-        uids_before = [t.get("uid") for t in before["data"]]
-        assert uid in uids_before, "Task should exist before completing"
+        summaries_before = [t.get("summary") for t in before["data"]]
+        assert "To complete" in summaries_before, "Task should exist before completing"
 
         comp_result = await caldav_tools.complete_task(uid=uid, list_name="Tasks")
         assert comp_result["result"] == "True"

--- a/tests/integration/test_webdav_file_ops.py
+++ b/tests/integration/test_webdav_file_ops.py
@@ -210,3 +210,198 @@ class TestCp:
         src = await webdav_tools.read("cpsrc.txt")
         dst = await webdav_tools.read("cpdst.txt")
         assert src["data"] == dst["data"] == "copy me"
+
+
+class TestFileBlacklist:
+    @pytest.mark.asyncio
+    async def test_ls_hides_blacklisted_directory(self, webdav_tools):
+        await webdav_tools.mkdir("blacklisted_dir")
+        await webdav_tools.mkdir("allowed_dir")
+        webdav_tools.valves.FILE_BLACKLIST = "blacklisted_dir"
+
+        listing = await webdav_tools.ls("")
+        assert listing["result"] == "True"
+        assert not any("blacklisted_dir" in p for p in listing["data"])
+        assert any("allowed_dir" in p for p in listing["data"])
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_ls_blocks_blacklisted_path(self, webdav_tools):
+        await webdav_tools.mkdir("bl_dir")
+        await webdav_tools.write_file("bl_dir/file.txt", "content")
+        webdav_tools.valves.FILE_BLACKLIST = "bl_dir"
+
+        result = await webdav_tools.ls("bl_dir")
+        assert result["result"] == "False"
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_glob_filters_blacklisted_files(self, webdav_tools):
+        await webdav_tools.mkdir("bl_sub")
+        await webdav_tools.write_file("allowed.txt", "a")
+        await webdav_tools.write_file("bl_sub/hidden.txt", "b")
+        webdav_tools.valves.FILE_BLACKLIST = "bl_sub"
+
+        result = await webdav_tools.glob("*.txt", path=".")
+        assert result["result"] == "True"
+        assert not any("bl_sub" in f for f in result["data"])
+        assert any("allowed.txt" in f for f in result["data"])
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_glob_blocks_blacklisted_path(self, webdav_tools):
+        await webdav_tools.mkdir("bl_glob")
+        await webdav_tools.write_file("bl_glob/f.txt", "x")
+        webdav_tools.valves.FILE_BLACKLIST = "bl_glob"
+
+        result = await webdav_tools.glob("*.txt", path="bl_glob")
+        assert result["result"] == "False"
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_grep_filters_blacklisted_files(self, webdav_tools):
+        await webdav_tools.mkdir("bl_grep")
+        await webdav_tools.write_file("allowed.py", "def foo():")
+        await webdav_tools.write_file("bl_grep/hidden.py", "def foo():")
+        webdav_tools.valves.FILE_BLACKLIST = "bl_grep"
+
+        result = await webdav_tools.grep("def foo", include="*.py")
+        assert result["result"] == "True"
+        assert not any("bl_grep" in m["file"] for m in result["data"])
+        assert any("allowed.py" in m["file"] for m in result["data"])
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_grep_blocks_blacklisted_path(self, webdav_tools):
+        await webdav_tools.mkdir("bl_grep2")
+        await webdav_tools.write_file("bl_grep2/f.py", "def bar():")
+        webdav_tools.valves.FILE_BLACKLIST = "bl_grep2"
+
+        result = await webdav_tools.grep("def bar", path="bl_grep2")
+        assert result["result"] == "False"
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_read_blocks_blacklisted_file(self, webdav_tools):
+        await webdav_tools.mkdir("bl_read")
+        await webdav_tools.write_file("bl_read/secret.txt", "hidden")
+        webdav_tools.valves.FILE_BLACKLIST = "bl_read"
+
+        result = await webdav_tools.read("bl_read/secret.txt")
+        assert result["result"] == "False"
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_write_file_blocks_blacklisted_path(self, webdav_tools):
+        webdav_tools.valves.FILE_BLACKLIST = "bl_write"
+
+        result = await webdav_tools.write_file("bl_write/newfile.txt", "data")
+        assert result["result"] == "False"
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_append_file_blocks_blacklisted_path(self, webdav_tools):
+        webdav_tools.valves.FILE_BLACKLIST = "bl_append"
+
+        result = await webdav_tools.append_file("bl_append/file.txt", "data")
+        assert result["result"] == "False"
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_edit_blocks_blacklisted_file(self, webdav_tools):
+        await webdav_tools.mkdir("bl_edit")
+        await webdav_tools.write_file("bl_edit/file.txt", "original")
+        webdav_tools.valves.FILE_BLACKLIST = "bl_edit"
+
+        result = await webdav_tools.edit("bl_edit/file.txt", "original", "replaced")
+        assert result["result"] == "False"
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_mkdir_blocks_blacklisted_path(self, webdav_tools):
+        webdav_tools.valves.FILE_BLACKLIST = "bl_mkdir"
+
+        result = await webdav_tools.mkdir("bl_mkdir/subdir")
+        assert result["result"] == "False"
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_rm_blocks_blacklisted_path(self, webdav_tools):
+        await webdav_tools.mkdir("bl_rm")
+        webdav_tools.valves.FILE_BLACKLIST = "bl_rm"
+
+        result = await webdav_tools.rm(["bl_rm"])
+        assert result["result"] == "False"
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_mv_blocks_blacklisted_src(self, webdav_tools):
+        await webdav_tools.mkdir("bl_mv")
+        await webdav_tools.write_file("bl_mv/src.txt", "move me")
+        webdav_tools.valves.FILE_BLACKLIST = "bl_mv"
+
+        result = await webdav_tools.mv("bl_mv/src.txt", "allowed.txt")
+        assert result["result"] == "False"
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_mv_blocks_blacklisted_dst(self, webdav_tools):
+        await webdav_tools.write_file("allowed_src.txt", "move me")
+        webdav_tools.valves.FILE_BLACKLIST = "bl_mv_dst"
+
+        result = await webdav_tools.mv("allowed_src.txt", "bl_mv_dst/dst.txt")
+        assert result["result"] == "False"
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_cp_blocks_blacklisted_src(self, webdav_tools):
+        await webdav_tools.mkdir("bl_cp")
+        await webdav_tools.write_file("bl_cp/src.txt", "copy me")
+        webdav_tools.valves.FILE_BLACKLIST = "bl_cp"
+
+        result = await webdav_tools.cp("bl_cp/src.txt", "allowed_dst.txt")
+        assert result["result"] == "False"
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_cp_blocks_blacklisted_dst(self, webdav_tools):
+        await webdav_tools.write_file("allowed_src2.txt", "copy me")
+        webdav_tools.valves.FILE_BLACKLIST = "bl_cp_dst"
+
+        result = await webdav_tools.cp("allowed_src2.txt", "bl_cp_dst/dst.txt")
+        assert result["result"] == "False"
+
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
+    @pytest.mark.asyncio
+    async def test_multiple_blacklist_entries(self, webdav_tools):
+        await webdav_tools.mkdir("bl_a")
+        await webdav_tools.mkdir("bl_b")
+        await webdav_tools.mkdir("allowed")
+        await webdav_tools.write_file("bl_a/f.txt", "a")
+        await webdav_tools.write_file("bl_b/f.txt", "b")
+        await webdav_tools.write_file("allowed/f.txt", "c")
+        webdav_tools.valves.FILE_BLACKLIST = "bl_a, bl_b"
+
+        listing = await webdav_tools.ls("")
+        assert listing["result"] == "True"
+        assert not any("bl_a" in p for p in listing["data"])
+        assert not any("bl_b" in p for p in listing["data"])
+        assert any("allowed" in p for p in listing["data"])
+
+        webdav_tools.valves.FILE_BLACKLIST = ""

--- a/tests/integration/test_webdav_file_ops.py
+++ b/tests/integration/test_webdav_file_ops.py
@@ -28,6 +28,55 @@ class TestLs:
         assert any("ls_testdir" in p for p in listing["data"])
         assert any("ls_testfile.txt" in p for p in listing["data"])
 
+    @pytest.mark.asyncio
+    async def test_ls_detail_shows_file_info(self, webdav_tools):
+        await webdav_tools.write_file("detail_file.txt", "x" * 100)
+
+        listing = await webdav_tools.ls("", detail=True)
+        assert listing["result"] == "True"
+        assert any("detail_file.txt" in entry for entry in listing["data"])
+        matching = [e for e in listing["data"] if "detail_file.txt" in e]
+        assert "[FILE]" in matching[0]
+        assert "2026-" in matching[0] or "2025-" in matching[0]
+        assert "B" in matching[0]
+
+    @pytest.mark.asyncio
+    async def test_ls_detail_shows_directory(self, webdav_tools):
+        await webdav_tools.mkdir("detail_dir")
+
+        listing = await webdav_tools.ls("", detail=True)
+        assert listing["result"] == "True"
+        matching = [e for e in listing["data"] if "detail_dir" in e]
+        assert matching
+        assert "[DIR]" in matching[0]
+
+    @pytest.mark.asyncio
+    async def test_ls_detail_vs_normal(self, webdav_tools):
+        await webdav_tools.write_file("compare.txt", "data")
+
+        normal = await webdav_tools.ls("")
+        detailed = await webdav_tools.ls("", detail=True)
+
+        assert normal["result"] == "True"
+        assert detailed["result"] == "True"
+        assert any("compare.txt" in p for p in normal["data"])
+        assert any("compare.txt" in p for p in detailed["data"])
+        assert any("[FILE]" in p for p in detailed["data"])
+
+    @pytest.mark.asyncio
+    async def test_ls_detail_hides_blacklisted(self, webdav_tools):
+        webdav_tools.valves.FILE_BLACKLIST = "secret"
+        await webdav_tools.write_file("visible.txt", "ok")
+        await webdav_tools.mkdir("secret")
+        await webdav_tools.write_file("secret/hidden.txt", "nope")
+
+        listing = await webdav_tools.ls("", detail=True)
+        assert listing["result"] == "True"
+        assert any("visible.txt" in e for e in listing["data"])
+        assert not any("secret" in e for e in listing["data"])
+        assert not any("hidden" in e for e in listing["data"])
+        webdav_tools.valves.FILE_BLACKLIST = ""
+
 
 class TestWriteFile:
     @pytest.mark.asyncio

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -5,7 +5,7 @@ Tests sandbox security, path traversal prevention, and normalization
 
 import pytest
 
-from owuinc.owuinc import is_whitelisted, validate_path
+from owuinc.owuinc import is_blacklisted, is_whitelisted, validate_path
 
 
 @pytest.fixture
@@ -241,3 +241,58 @@ class TestValidatePathSecurityEdgeCases:
         """Four dots contain .. and should be blocked"""
         with pytest.raises(Exception, match="traversal not allowed"):
             validate_path("....", valves)
+
+
+class TestIsBlacklisted:
+    """Test blacklist prefix matching logic"""
+
+    def test_empty_blacklist_returns_false(self):
+        assert is_blacklisted("", "any/path") is False
+
+    def test_exact_match(self):
+        assert is_blacklisted("foo", "foo") is True
+
+    def test_prefix_match(self):
+        assert is_blacklisted("foo/bar", "foo/bar/baz/file.txt") is True
+
+    def test_prefix_match_deep(self):
+        assert is_blacklisted("foo", "foo/a/b/c/deep/file.txt") is True
+
+    def test_no_match_different_prefix(self):
+        assert is_blacklisted("foo", "other/file.txt") is False
+
+    def test_no_match_similar_name(self):
+        assert is_blacklisted("foo", "foobar/file.txt") is False
+
+    def test_no_match_substring_without_separator(self):
+        assert is_blacklisted("foo", "Myfoo/file.txt") is False
+
+    def test_comma_separated_multiple(self):
+        assert is_blacklisted("foo, bar", "bar/file.txt") is True
+
+    def test_comma_separated_first_match(self):
+        assert is_blacklisted("foo, bar", "foo/file.txt") is True
+
+    def test_comma_separated_no_match(self):
+        assert is_blacklisted("foo, bar", "other/file.txt") is False
+
+    def test_whitespace_normalized(self):
+        assert is_blacklisted("  foo  ,  bar  ", "foo/file.txt") is True
+
+    def test_trailing_comma_filtered(self):
+        assert is_blacklisted("foo,", "foo/file.txt") is True
+
+    def test_single_level_path(self):
+        assert is_blacklisted("foo", "foo") is True
+
+    def test_multilevel_blacklist_exact(self):
+        assert is_blacklisted("a/b/c", "a/b/c/file.txt") is True
+
+    def test_multilevel_blacklist_exact_match(self):
+        assert is_blacklisted("a/b/c", "a/b/c") is True
+
+    def test_multilevel_blacklist_no_partial_match(self):
+        assert is_blacklisted("a/b/c", "a/b/file.txt") is False
+
+    def test_leading_slash_stripped_by_caller(self):
+        assert is_blacklisted("foo", "foo/file.txt") is True

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -5,7 +5,7 @@ Tests sandbox security, path traversal prevention, and normalization
 
 import pytest
 
-from owuinc.owuinc import is_blacklisted, is_whitelisted, validate_path
+from owuinc.owuinc import Tools, is_blacklisted, is_whitelisted, validate_path
 
 
 @pytest.fixture
@@ -296,3 +296,70 @@ class TestIsBlacklisted:
 
     def test_leading_slash_stripped_by_caller(self):
         assert is_blacklisted("foo", "foo/file.txt") is True
+
+
+class TestFormatSize:
+    """Test _format_size helper"""
+
+    @pytest.fixture
+    def tools(self):
+        return Tools()
+
+    def test_zero_bytes(self, tools):
+        assert tools._format_size("0") == "0 B"
+
+    def test_small_bytes(self, tools):
+        assert tools._format_size("42") == "42 B"
+
+    def test_exactly_1023_bytes(self, tools):
+        assert tools._format_size("1023") == "1023 B"
+
+    def test_kilobytes(self, tools):
+        assert tools._format_size("1024") == "1.0 KB"
+
+    def test_large_kilobytes(self, tools):
+        assert tools._format_size("2048") == "2.0 KB"
+
+    def test_megabytes(self, tools):
+        assert tools._format_size("1048576") == "1.0 MB"
+
+    def test_gigabytes(self, tools):
+        assert tools._format_size("1073741824") == "1.0 GB"
+
+    def test_terabytes(self, tools):
+        assert tools._format_size("1099511627776") == "1.0 TB"
+
+    def test_petabytes(self, tools):
+        assert tools._format_size("1125899906842624") == "1.0 PB"
+
+    def test_invalid_input(self, tools):
+        assert tools._format_size("abc") == "abc"
+
+    def test_none_input(self, tools):
+        assert tools._format_size(None) is None  # type: ignore
+
+
+class TestFormatDatetime:
+    """Test _format_datetime helper"""
+
+    @pytest.fixture
+    def tools(self):
+        return Tools()
+
+    def test_empty_string(self, tools):
+        assert tools._format_datetime("") == "n/a"
+
+    def test_none_input(self, tools):
+        assert tools._format_datetime(None) == "n/a"  # type: ignore
+
+    def test_iso_format_with_z(self, tools):
+        result = tools._format_datetime("2026-06-22T10:30:00Z")
+        assert "2026-06-22" in result
+
+    def test_iso_format_with_offset(self, tools):
+        result = tools._format_datetime("2026-06-22T10:30:00+00:00")
+        assert "2026-06-22" in result
+
+    def test_invalid_format_returns_original(self, tools):
+        result = tools._format_datetime("not-a-date")
+        assert result == "not-a-date"


### PR DESCRIPTION
- FILE_BLACKLIST valve — comma-separated path prefixes that block and filter all file operations (ls, glob, grep, read, write, edit, rm, mv, cp, mkdir).
- cp recursive — copies nested directories
- mv overwrite — handles existing destinations
- get_tasks drops uid — 36-char hex per task was unused